### PR TITLE
Improve Russian translation

### DIFF
--- a/logdoctor/translations/LogDoctor_ru_RU.ts
+++ b/logdoctor/translations/LogDoctor_ru_RU.ts
@@ -5,23 +5,19 @@
     <name>Changelog</name>
     <message>
         <source>Versions</source>
-        <translation type="unfinished">Версии</translation>
-    </message>
-    <message>
-        <source>Version 4</source>
-        <translation type="unfinished">Версия 4</translation>
+        <translation>Версии</translation>
     </message>
     <message>
         <source>Version 3</source>
-        <translation type="unfinished">Версия 3</translation>
+        <translation>Версия 3</translation>
     </message>
     <message>
         <source>Version 2</source>
-        <translation type="unfinished">Версия 2</translation>
+        <translation>Версия 2</translation>
     </message>
     <message>
         <source>Version 1</source>
-        <translation type="unfinished">Версия 1</translation>
+        <translation>Версия 1</translation>
     </message>
     <message>
         <source>C++17</source>
@@ -33,2145 +29,2004 @@
     </message>
     <message>
         <source>Build scripts</source>
-        <translation type="unfinished">Построить скрипты</translation>
+        <translation>Скрипты сборки</translation>
     </message>
     <message>
         <source>Cross-platform compatibility:</source>
-        <translation type="unfinished">Кроссплатформенная совместимость:</translation>
+        <translation>Кроссплатформенная совместимость:</translation>
     </message>
     <message>
         <source>Linux</source>
-        <translation type="unfinished">Linux</translation>
+        <translation>Linux</translation>
     </message>
     <message>
         <source>BSD</source>
-        <translation type="unfinished">BSD</translation>
+        <translation>BSD</translation>
     </message>
     <message>
         <source>Windows</source>
-        <translation type="unfinished">Windows</translation>
+        <translation>Windows</translation>
     </message>
     <message>
         <source>OSX</source>
-        <translation type="unfinished">OSX</translation>
+        <translation>OSX</translation>
     </message>
     <message>
         <source>Statistics:</source>
-        <translation type="unfinished">Статистика:</translation>
+        <translation>Статистика:</translation>
     </message>
     <message>
         <source>Warnings</source>
-        <translation type="unfinished">Предупреждения</translation>
+        <translation>Предупреждения</translation>
     </message>
     <message>
         <source>Speed</source>
-        <translation type="unfinished">Скорость</translation>
+        <translation>Скорость</translation>
     </message>
     <message>
         <source>Counts</source>
-        <translation type="unfinished">Графиня</translation>
+        <translation>Подсчёты</translation>
     </message>
     <message>
         <source>Daytime</source>
-        <translation type="unfinished">дневное время</translation>
+        <translation>Время суток</translation>
     </message>
     <message>
         <source>Relational</source>
-        <translation type="unfinished">относительный</translation>
+        <translation>Связи</translation>
     </message>
     <message>
         <source>Globals</source>
-        <translation type="unfinished">Глобал</translation>
+        <translation>Глобальные переменные</translation>
     </message>
     <message>
         <source>Translations:</source>
-        <translation type="unfinished">Переводы:</translation>
+        <translation>Переводы:</translation>
     </message>
     <message>
         <source>Italian</source>
-        <translation type="unfinished">итальянский</translation>
+        <translation>Итальянский</translation>
     </message>
     <message>
         <source>Spanish</source>
-        <translation type="unfinished">испанский</translation>
+        <translation>Испанский</translation>
     </message>
     <message>
         <source>French</source>
-        <translation type="unfinished">французский</translation>
+        <translation>Французский</translation>
     </message>
     <message>
         <source>Tools:</source>
-        <translation type="unfinished">Инструменты:</translation>
+        <translation>Инструменты:</translation>
     </message>
     <message>
         <source>Block note</source>
-        <translation type="unfinished">Блокнот</translation>
+        <translation>Блокнот</translation>
     </message>
     <message>
         <source>Utilities:</source>
-        <translation type="unfinished">Коммунальные услуги:</translation>
+        <translation>Утилиты</translation>
     </message>
     <message>
         <source>Infos viewer</source>
-        <translation type="unfinished">Инфо-зритель</translation>
+        <translation>Просмотр информации</translation>
     </message>
     <message>
         <source>Updates checker</source>
-        <translation type="unfinished">Проверка обновлений</translation>
+        <translation>Проверка обновлений</translation>
     </message>
     <message>
         <source>Themes:</source>
-        <translation type="unfinished">Темы:</translation>
+        <translation>Темы:</translation>
     </message>
     <message>
         <source>Dark</source>
-        <translation type="unfinished">темный</translation>
+        <translation>Тёмная</translation>
     </message>
     <message>
         <source>Light</source>
-        <translation type="unfinished">Свет</translation>
+        <translation>Светлая</translation>
     </message>
     <message>
         <source>Improvements and fixes</source>
-        <translation type="unfinished">Улучшения и исправления</translation>
+        <translation>Улучшения и исправления</translation>
     </message>
     <message>
         <source>New themes:</source>
-        <translation type="unfinished">Новые темы:</translation>
+        <translation>Новые темы:</translation>
     </message>
     <message>
         <source>Ash</source>
-        <translation type="unfinished">Эш</translation>
+        <translation>Ash</translation>
     </message>
     <message>
         <source>Candy</source>
-        <translation type="unfinished">конфетка</translation>
+        <translation>Конфетная</translation>
     </message>
     <message>
         <source>Forest</source>
-        <translation type="unfinished">лес</translation>
+        <translation>Лесная</translation>
     </message>
     <message>
         <source>Powder</source>
-        <translation type="unfinished">Порошок</translation>
+        <translation>Пудровая</translation>
     </message>
     <message>
         <source>Restyled GUI</source>
-        <translation type="unfinished">Рестайлинговый GUI</translation>
+        <translation>Обновлённый интерфейс</translation>
     </message>
     <message>
         <source>Restyled dialogs</source>
-        <translation type="unfinished">Рестайлинговые диалоги</translation>
+        <translation>Обновлённые диалоги</translation>
     </message>
     <message>
         <source>Doxygen documentation</source>
-        <translation type="unfinished">Доксигенная документация</translation>
+        <translation>Документация Doxygen</translation>
     </message>
     <message>
         <source>Mini-Games:</source>
-        <translation type="unfinished">Мини-игры:</translation>
+        <translation>Мини-игры:</translation>
     </message>
     <message>
         <source>Criss-cross</source>
-        <translation type="unfinished">крест-накрест</translation>
+        <translation>Крестики-нолики</translation>
     </message>
     <message>
         <source>Snake</source>
-        <translation type="unfinished">Змея</translation>
+        <translation>Змейка</translation>
     </message>
     <message>
         <source>Changed default paths</source>
-        <translation type="unfinished">Измененные пути по умолчанию</translation>
+        <translation>Изменены пути по умолчанию</translation>
     </message>
     <message>
         <source>New game modes for Snake</source>
-        <translation type="unfinished">Новые игровые режимы для Snake</translation>
+        <translation>Новые режимы игры для Змейки</translation>
     </message>
     <message>
         <source>Hunt</source>
-        <translation type="unfinished">охота</translation>
+        <translation>Охота</translation>
     </message>
     <message>
         <source>Battle</source>
-        <translation type="unfinished">Битва</translation>
+        <translation>Битва</translation>
     </message>
     <message>
         <source>New translations:</source>
-        <translation type="unfinished">Новые переводы:</translation>
+        <translation>Новые переводы:</translation>
     </message>
     <message>
         <source>Japanese</source>
-        <translation type="unfinished">японский</translation>
+        <translation>Японский</translation>
     </message>
     <message>
         <source>Portuguese</source>
-        <translation type="unfinished">португальский</translation>
+        <translation>Португальский</translation>
     </message>
     <message>
         <source>Code improvements</source>
-        <translation type="unfinished">Улучшение кода</translation>
+        <translation>Оптимизация кода</translation>
     </message>
     <message>
         <source>Performance improvements</source>
-        <translation type="unfinished">Повышение эффективности</translation>
+        <translation>Повышение производительности</translation>
     </message>
     <message>
         <source>Added tests suite:</source>
-        <translation type="unfinished">Добавлен набор тестов:</translation>
+        <translation>Добавлен набор тестов:</translation>
     </message>
     <message>
         <source>white box tests</source>
-        <translation type="unfinished">Белая коробка</translation>
+        <translation>тесты "белого ящика"</translation>
     </message>
     <message>
         <source>Customized charts themes</source>
-        <translation type="unfinished">Настраиваемые темы диаграмм</translation>
+        <translation>Настраиваемые темы графиков</translation>
     </message>
     <message>
         <source>Fixes</source>
-        <translation type="unfinished">исправления</translation>
+        <translation>Исправления</translation>
     </message>
     <message>
         <source>Tests improvements</source>
-        <translation type="unfinished">Улучшения тестов</translation>
+        <translation>Улучшения тестов</translation>
     </message>
     <message>
         <source>Docker support</source>
-        <translation type="unfinished">Поддержка Docker</translation>
+        <translation>Поддержка Docker</translation>
     </message>
     <message>
         <source>Upgrade to C++20</source>
-        <translation type="unfinished">Обновление до C++20</translation>
+        <translation>Обновление до C++20</translation>
     </message>
     <message>
         <source>Upgrade to Qt6</source>
-        <translation type="unfinished">Обновление до Qt6</translation>
+        <translation>Обновление до Qt6</translation>
     </message>
     <message>
         <source>Restyled themes</source>
-        <translation type="unfinished">Рестайлинговые темы</translation>
+        <translation>Обновлённые темы</translation>
     </message>
     <message>
         <source>Redesigned configs section</source>
-        <translation type="unfinished">Переделанный раздел конфигураций</translation>
+        <translation>Переделан раздел настроек</translation>
+    </message>
+    <message>
+        <source>Version 4</source>
+        <translation>Версия 4</translation>
     </message>
     <message>
         <source>Stability improvements</source>
-        <translation type="unfinished">Повышение стабильности</translation>
+        <translation>Повышена стабильность</translation>
     </message>
     <message>
         <source>Generating warnings dinamically</source>
-        <translation type="unfinished">Предупреждения динамически</translation>
+        <translation>Динамическая генерация предупреждений</translation>
     </message>
     <message>
         <source>New tool:</source>
-        <translation type="unfinished">Новый инструмент:</translation>
+        <translation>Новый инструмент:</translation>
     </message>
     <message>
         <source>Changelog</source>
-        <translation type="unfinished">Изменить</translation>
-    </message>
-    <message>
-        <source>Tweakable parameters for some of the charts:</source>
-        <translation type="unfinished">Настраиваемые параметры для некоторых графиков:</translation>
+        <translation>История изменений</translation>
     </message>
     <message>
         <source>Improved project structure</source>
-        <translation type="unfinished">Улучшенная структура проекта</translation>
+        <translation>Улучшена структура проекта</translation>
     </message>
     <message>
         <source>Modernized Cmake usage</source>
-        <translation type="unfinished">модернизированный Использование крема</translation>
+        <translation>Современное использование CMake</translation>
+    </message>
+    <message>
+        <source>Tweakable parameters for some of the charts:</source>
+        <translation>Настраиваемые параметры некоторых графиков:</translation>
     </message>
 </context>
 <context>
     <name>Crapinfo</name>
     <message>
         <source>Version</source>
-        <translation type="unfinished">Версия</translation>
-    </message>
-    <message>
-        <source>Currently installed version of the software</source>
-        <translation type="unfinished">В настоящее время установлена версия программного обеспечения</translation>
+        <translation>Версия</translation>
     </message>
     <message>
         <source>Repository links</source>
-        <translation type="unfinished">Ссылки на хранилища</translation>
+        <translation>Ссылки на репозиторий</translation>
     </message>
     <message>
         <source>Paths</source>
-        <translation type="unfinished">Пути</translation>
+        <translation>Пути</translation>
+    </message>
+    <message>
+        <source>Currently installed version of the software</source>
+        <translation>Текущая установленная версия программы</translation>
     </message>
     <message>
         <source>The path of the executable file</source>
-        <translation type="unfinished">Путь исполняемого файла</translation>
+        <translation>Путь к исполняемому файлу</translation>
     </message>
     <message>
         <source>Executable</source>
-        <translation type="unfinished">исполняемый</translation>
+        <translation>Исполняемый файл</translation>
     </message>
     <message>
         <source>The path where the configuration file gets saved and searched in</source>
-        <translation type="unfinished">Путь, по которому файл конфигурации сохраняется и ищется в</translation>
+        <translation>Путь, по которому сохраняется и ищется конфигурационный файл</translation>
     </message>
     <message>
         <source>Configuration file</source>
-        <translation type="unfinished">Файл конфигурации</translation>
+        <translation>Файл конфигурации</translation>
     </message>
     <message>
         <source>The path where the application searches for extra resources</source>
-        <translation type="unfinished">Путь, по которому приложение ищет дополнительные ресурсы</translation>
+        <translation>Путь, по которому приложение ищет дополнительные ресурсы</translation>
     </message>
     <message>
         <source>Application data</source>
-        <translation type="unfinished">Данные приложения</translation>
+        <translation>Данные приложения</translation>
     </message>
 </context>
+
 <context>
     <name>Crapnote</name>
     <message>
         <source>Reduce the font size</source>
-        <translation type="unfinished">Уменьшить размер шрифта</translation>
+        <translation>Уменьшить размер шрифта</translation>
     </message>
     <message>
         <source>Font size</source>
-        <translation type="unfinished">Размер шрифта</translation>
+        <translation>Размер шрифта</translation>
     </message>
     <message>
         <source>Increase the font size</source>
-        <translation type="unfinished">Увеличить размер шрифта</translation>
+        <translation>Увеличить размер шрифта</translation>
     </message>
 </context>
+
 <context>
     <name>Crappath</name>
     <message>
         <source>Choose</source>
-        <translation type="unfinished">Выбрать</translation>
+        <translation>Выбрать</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished">отменить</translation>
+        <translation>Отмена</translation>
     </message>
 </context>
+
 <context>
     <name>Crapup</name>
     <message>
         <source>Checking for updates</source>
-        <translation type="unfinished">Проверка обновлений</translation>
+        <translation>Проверка обновлений</translation>
+    </message>
+    <message>
+        <source>Failed to establish a connection</source>
+        <translation>Не удалось установить соединение</translation>
+    </message>
+    <message>
+        <source>Connection error, please try again later</source>
+        <translation>Ошибка подключения, попробуйте позже</translation>
+    </message>
+    <message>
+        <source>Connection timed out</source>
+        <translation>Время ожидания подключения истекло</translation>
     </message>
     <message>
         <source>New version available</source>
-        <translation type="unfinished">Новая версия доступна</translation>
-    </message>
-    <message>
-        <source>A new version is available!
-Please visit LogDoctor&apos;s git repository and follow the instruction about how to update</source>
-        <translation type="unfinished">Доступна новая версия!
-Пожалуйста, посетите Git-хранилище LogDoctor и следуйте инструкциям о том, как обновить</translation>
+        <translation>Доступна новая версия</translation>
     </message>
     <message>
         <source>No update found</source>
-        <translation type="unfinished">Обновлений не найдено</translation>
+        <translation>Обновлений не найдено</translation>
     </message>
     <message>
         <source>LogDoctor is up-to-date</source>
-        <translation type="unfinished">LogDoctor обновляется</translation>
+        <translation>LogDoctor обновлён до последней версии</translation>
     </message>
     <message>
         <source>:/</source>
-        <translation type="unfinished">:/</translation>
+        <translation>:/</translation>
     </message>
     <message>
         <source>You&apos;re running a version from the future!
 Your version is beyond the current upstream version
 Are you running the original LogDoctor?
 Please visit the LogDoctor&apos;s repository and get a fresh version of it</source>
-        <translation type="unfinished">Ты запускаешь версию из будущего!
-Ваша версия выходит за рамки текущей версии
-Вы используете оригинальный LogDoctor?
-Пожалуйста, посетите репозиторий LogDoctor и получите его новую версию</translation>
-    </message>
-    <message>
-        <source>Failed to establish a connection</source>
-        <translation type="unfinished">Не удалось установить связь</translation>
-    </message>
-    <message>
-        <source>Connection error, please try again later</source>
-        <translation type="unfinished">Ошибка подключения, пожалуйста, попробуйте позже</translation>
-    </message>
-    <message>
-        <source>Connection timed out</source>
-        <translation type="unfinished">Связь отключена</translation>
+        <translation>Вы используете версию из будущего!
+Ваша версия новее, чем текущая в репозитории.
+Вы точно используете оригинальный LogDoctor?
+Пожалуйста, посетите репозиторий LogDoctor и скачайте свежую версию.</translation>
     </message>
     <message>
         <source>Version check failed</source>
-        <translation type="unfinished">Проверка версий провалилась</translation>
-    </message>
-    <message>
-        <source>An error occured while parsing:
-version mark not found</source>
-        <translation type="unfinished">Во время разбора произошла ошибка:
-Знак версии не найден</translation>
+        <translation>Ошибка проверки версии</translation>
     </message>
     <message>
         <source>An error occured while parsing:
 malformed version</source>
-        <translation type="unfinished">Во время разбора произошла ошибка:
-искаженная версия</translation>
+        <translation>Ошибка при разборе:
+некорректный формат версии</translation>
     </message>
     <message>
         <source>An error occured while comparing:
 malformed upstream version</source>
-        <translation type="unfinished">Произошла ошибка при сравнении:
-Неправильная версия Upstream</translation>
+        <translation>Ошибка при сравнении:
+некорректная версия в репозитории</translation>
+    </message>
+    <message>
+        <source>A new version is available!
+Please visit LogDoctor&apos;s git repository and follow the instruction about how to update</source>
+        <translation>Доступна новая версия!
+Перейдите в Git-репозиторий LogDoctor и следуйте инструкциям по обновлению</translation>
+    </message>
+    <message>
+        <source>An error occured while parsing:
+version mark not found</source>
+        <translation>Ошибка при разборе:
+маркер версии не найден</translation>
     </message>
 </context>
+
 <context>
     <name>CrissCross</name>
     <message>
-        <source>Victory</source>
-        <translation type="unfinished">Победа</translation>
-    </message>
-    <message>
         <source>You beated me!</source>
-        <translation type="unfinished">Ты меня избил!</translation>
+        <translation>Ты победил меня!</translation>
     </message>
     <message>
         <source>This time you lost!</source>
-        <translation type="unfinished">На этот раз вы проиграли!</translation>
+        <translation>На этот раз ты проиграл!</translation>
+    </message>
+    <message>
+        <source>Victory</source>
+        <translation>Победа</translation>
     </message>
     <message>
         <source>Draw</source>
-        <translation type="unfinished">рисовать</translation>
+        <translation>Ничья</translation>
     </message>
     <message>
         <source>Nice match</source>
-        <translation type="unfinished">Отличный матч</translation>
+        <translation>Хорошая партия</translation>
     </message>
 </context>
 <context>
     <name>DialogBool</name>
     <message>
         <source>Yes</source>
-        <translation type="unfinished">Да</translation>
+        <translation>Да</translation>
     </message>
     <message>
         <source>No</source>
-        <translation type="unfinished">Нет</translation>
+        <translation>Нет</translation>
     </message>
 </context>
+
 <context>
     <name>DialogIda</name>
     <message>
         <source>Ignore</source>
-        <translation type="unfinished">Игнорировать</translation>
+        <translation>Игнорировать</translation>
     </message>
     <message>
         <source>Discard</source>
-        <translation type="unfinished">выбрасывать</translation>
+        <translation>Отменить</translation>
     </message>
     <message>
         <source>Abort</source>
-        <translation type="unfinished">отменять</translation>
+        <translation>Прервать</translation>
     </message>
 </context>
+
 <context>
     <name>DialogMsg</name>
     <message>
         <source>Ok</source>
-        <translation type="unfinished">Хорошо</translation>
+        <translation>Ок</translation>
     </message>
 </context>
 <context>
     <name>DialogSec</name>
     <message>
-        <source>One of the lists has an invalid item</source>
-        <translation type="unfinished">Один из списков имеет недействительный элемент</translation>
-    </message>
-    <message>
         <source>An error occured while reading the configuration file</source>
-        <translation type="unfinished">Произошла ошибка при чтении файла конфигурации</translation>
+        <translation>Произошла ошибка при чтении конфигурационного файла</translation>
     </message>
     <message>
         <source>An error occured while parsing configuration file&apos;s data</source>
-        <translation type="unfinished">Произошла ошибка при анализе данных файла конфигурации</translation>
+        <translation>Произошла ошибка при разборе данных конфигурационного файла</translation>
     </message>
     <message>
         <source>Failed to create the configuration file&apos;s directory</source>
-        <translation type="unfinished">Не удалось создать каталог конфигурационного файла</translation>
-    </message>
-    <message>
-        <source>Failed to create the configuration file</source>
-        <translation type="unfinished">Не удалось создать конфигурационный файл</translation>
+        <translation>Не удалось создать каталог для конфигурационного файла</translation>
     </message>
     <message>
         <source>An error occured while writing the configuration file</source>
-        <translation type="unfinished">При написании файла конфигурации произошла ошибка</translation>
+        <translation>Произошла ошибка при записи конфигурационного файла</translation>
     </message>
     <message>
         <source>An error occured while preparing the configuration file&apos;s data</source>
-        <translation type="unfinished">Ошибка произошла при подготовке данных файла конфигурации</translation>
-    </message>
-    <message>
-        <source>The path contains a symlink</source>
-        <translation type="unfinished">Путь содержит симлинк</translation>
-    </message>
-    <message>
-        <source>The file does not exist</source>
-        <translation type="unfinished">Файл не существует</translation>
+        <translation>Произошла ошибка при подготовке данных конфигурационного файла</translation>
     </message>
     <message>
         <source>Failed to create the database backups&apos; directory</source>
-        <translation type="unfinished">Не удалось создать каталог резервных копий базы данных</translation>
+        <translation>Не удалось создать каталог резервных копий базы данных</translation>
     </message>
     <message>
         <source>Failed to copy the database file</source>
-        <translation type="unfinished">Не удалось скопировать файл базы данных</translation>
+        <translation>Не удалось скопировать файл базы данных</translation>
     </message>
     <message>
         <source>Failed to update the backups</source>
-        <translation type="unfinished">Не удалось обновить резервные копии</translation>
-    </message>
-    <message>
-        <source>Failed to create the directory</source>
-        <translation type="unfinished">Не удалось создать каталог</translation>
-    </message>
-    <message>
-        <source>Unrecognized entry</source>
-        <translation type="unfinished">Непризнанный въезд</translation>
-    </message>
-    <message>
-        <source>Size of the file</source>
-        <translation type="unfinished">Размер файла</translation>
-    </message>
-    <message>
-        <source>Warning size parameter</source>
-        <translation type="unfinished">Параметр размера предупреждения</translation>
+        <translation>Не удалось обновить резервные копии</translation>
     </message>
     <message>
         <source>Failed to read gzipped file</source>
-        <translation type="unfinished">Не удалось прочитать gzipped файл</translation>
+        <translation>Не удалось прочитать сжатый (gzip) файл</translation>
     </message>
     <message>
-        <source>An error occured while parsing the format string</source>
-        <translation type="unfinished">Произошла ошибка при анализе строки формата</translation>
-    </message>
-    <message>
-        <source>Available memory</source>
-        <translation type="unfinished">Доступная память</translation>
-    </message>
-    <message>
-        <source>Size of the logs</source>
-        <translation type="unfinished">Размер бревен</translation>
-    </message>
-    <message>
-        <source>An error occured while reading the gzipped file</source>
-        <translation type="unfinished">Произошла ошибка при чтении gzipped файла</translation>
-    </message>
-    <message>
-        <source>An error occured while reading the file</source>
-        <translation type="unfinished">Во время чтения файла произошла ошибка</translation>
-    </message>
-    <message>
-        <source>Something failed while handling the file</source>
-        <translation type="unfinished">Что-то не получилось при обработке файла</translation>
-    </message>
-    <message>
-        <source>An error occured while working on the database</source>
-        <translation type="unfinished">Во время работы над базой данных произошла ошибка</translation>
-    </message>
-    <message>
-        <source>Aborting</source>
-        <translation type="unfinished">аборт</translation>
-    </message>
-    <message>
-        <source>Invalid locale</source>
-        <translation type="unfinished">Недействительная локализация</translation>
-    </message>
-    <message>
-        <source>Unexpected locale format</source>
-        <translation type="unfinished">Неожиданный локальный формат</translation>
-    </message>
-    <message>
-        <source>If you haven&apos;t manually edited the configuration file,
-please report this issue</source>
-        <translation type="unfinished">Если вы не отредактировали файл конфигурации вручную,
-Пожалуйста, сообщите об этом вопросе</translation>
-    </message>
-    <message>
-        <source>The given locale is not an accepted language</source>
-        <translation type="unfinished">Данная местность не является общепринятым языком</translation>
-    </message>
-    <message>
-        <source>If you&apos;d like to have this locale in LogDoctor,
-please follow the instruction on the repository page</source>
-        <translation type="unfinished">Если вы хотите, чтобы это место в LogDoctor,
-Пожалуйста, следуйте инструкции на странице репозитория</translation>
-    </message>
-    <message>
-        <source>Configuration file not found</source>
-        <translation type="unfinished">Файл конфигурации не найден</translation>
-    </message>
-    <message>
-        <source>Unable to retrieve the configuration file</source>
-        <translation type="unfinished">Невозможность восстановления файла конфигурации</translation>
-    </message>
-    <message>
-        <source>Skipping</source>
-        <translation type="unfinished">пропуск</translation>
-    </message>
-    <message>
-        <source>An error occured while handling the configuration file</source>
-        <translation type="unfinished">При обработке файла конфигурации произошла ошибка</translation>
-    </message>
-    <message>
-        <source>Failed to write the configuration file</source>
-        <translation type="unfinished">Не удалось записать файл конфигурации</translation>
-    </message>
-    <message>
-        <source>Current configuration not saved</source>
-        <translation type="unfinished">Текущая конфигурация не сохранена</translation>
-    </message>
-    <message>
-        <source>File not readable</source>
-        <translation type="unfinished">Файл не читается</translation>
-    </message>
-    <message>
-        <source>The file is not readable</source>
-        <translation type="unfinished">Файл не читается</translation>
-    </message>
-    <message>
-        <source>File not writable</source>
-        <translation type="unfinished">Файл не пишется</translation>
-    </message>
-    <message>
-        <source>The file is not writable</source>
-        <translation type="unfinished">Файл не является письменным</translation>
-    </message>
-    <message>
-        <source>Directory not writable</source>
-        <translation type="unfinished">Справочник Not Writable</translation>
-    </message>
-    <message>
-        <source>The directory is not writable</source>
-        <translation type="unfinished">Каталог не является письменным</translation>
-    </message>
-    <message>
-        <source>Invalid path</source>
-        <translation type="unfinished">Неверный путь</translation>
-    </message>
-    <message>
-        <source>Failed applying configuration</source>
-        <translation type="unfinished">Неудачная настройка</translation>
-    </message>
-    <message>
-        <source>Invalid configuration lines</source>
-        <translation type="unfinished">Недействительные линии конфигурации</translation>
-    </message>
-    <message>
-        <source>Has not been possible to apply some of the configurations</source>
-        <translation type="unfinished">Не удалось применить некоторые конфигурации</translation>
-    </message>
-    <message>
-        <source>If you choose to proceed, all of the unapplied configurations will be lost
-Continue?</source>
-        <translation type="unfinished">Если вы решите продолжить, все непримененные конфигурации будут потеряны.
-Продолжай?</translation>
-    </message>
-    <message>
-        <source>Failed to retrieve the help file</source>
-        <translation type="unfinished">Не удалось восстановить файл помощи</translation>
-    </message>
-    <message>
-        <source>An error occured while getting the help file</source>
-        <translation type="unfinished">Произошла ошибка при получении файла справки</translation>
-    </message>
-    <message>
-        <source>Additional resources can be downloaded from the git repo</source>
-        <translation type="unfinished">Дополнительные ресурсы можно скачать из git repo</translation>
-    </message>
-    <message>
-        <source>Unable to retrieve the file</source>
-        <translation type="unfinished">Невозможность восстановить файл</translation>
-    </message>
-    <message>
-        <source>Invalid string</source>
-        <translation type="unfinished">Недействительная струна</translation>
-    </message>
-    <message>
-        <source>The given string is invalid and cannot be added to the list
-
-Please correct it and retry</source>
-        <translation type="unfinished">Данная строка недействительна и не может быть добавлена в список.
-
-Пожалуйста, исправьте это и повторите</translation>
-    </message>
-    <message>
-        <source>QSql driver not found</source>
-        <translation type="unfinished">Водитель QSql не найден</translation>
-    </message>
-    <message>
-        <source>Failed to retrieve the driver needed to handle the database</source>
-        <translation type="unfinished">Не удалось найти водителя, необходимого для работы с базой данных</translation>
-    </message>
-    <message>
-        <source>File not found</source>
-        <translation type="unfinished">Файл не найден</translation>
-    </message>
-    <message>
-        <source>Failed to retrieve the database file</source>
-        <translation type="unfinished">Не удалось восстановить файл базы данных</translation>
+        <source>Discard it and continue, or Abort all and exit?</source>
+        <translation>Отклонить и продолжить или прервать всё и выйти?</translation>
     </message>
     <message>
         <source>Create a new database?</source>
-        <translation type="unfinished">Создать новую базу данных?</translation>
+        <translation>Создать новую базу данных?</translation>
     </message>
     <message>
-        <source>The database contains an unexpected table</source>
-        <translation type="unfinished">База данных содержит неожиданную таблицу</translation>
+        <source>An error occured</source>
+        <translation>Произошла ошибка</translation>
     </message>
     <message>
-        <source>Unexpected table</source>
-        <translation type="unfinished">Неожиданный стол</translation>
+        <source>Failed renaming</source>
+        <translation>Не удалось переименовать</translation>
     </message>
     <message>
-        <source>It seems that the database is missing a table</source>
-        <translation type="unfinished">В базе данных отсутствует таблица</translation>
+        <source>Invalid locale</source>
+        <translation>Неверная локаль</translation>
     </message>
     <message>
-        <source>Table not found</source>
-        <translation type="unfinished">Таблица не найдена</translation>
+        <source>Configuration file not found</source>
+        <translation>Конфигурационный файл не найден</translation>
     </message>
     <message>
-        <source>The database contains an unexpected column</source>
-        <translation type="unfinished">База данных содержит неожиданный столбец</translation>
-    </message>
-    <message>
-        <source>Unexpected column</source>
-        <translation type="unfinished">Неожиданная колонка</translation>
-    </message>
-    <message>
-        <source>It seems that the table is missing a column</source>
-        <translation type="unfinished">Кажется, что в столе отсутствует колонка</translation>
-    </message>
-    <message>
-        <source>Column not found</source>
-        <translation type="unfinished">Колонна не найдена</translation>
-    </message>
-    <message>
-        <source>A column has an unexpected data-type</source>
-        <translation type="unfinished">Колонка имеет неожиданный тип данных</translation>
-    </message>
-    <message>
-        <source>Unexpected data-type</source>
-        <translation type="unfinished">Неожиданный тип данных</translation>
-    </message>
-    <message>
-        <source>This database will be renamed with a trailing &apos;.copy&apos; and a new one will be created.
-Continue?</source>
-        <translation type="unfinished">Эта база данных будет переименована в .copy и будет создана новая.
-Продолжай?</translation>
-    </message>
-    <message>
-        <source>Database created</source>
-        <translation type="unfinished">Создана база данных</translation>
-    </message>
-    <message>
-        <source>Successfully created a new database</source>
-        <translation type="unfinished">Успешно создана новая база данных</translation>
+        <source>Failed to retrieve the help file</source>
+        <translation>Не удалось получить файл справки</translation>
     </message>
     <message>
         <source>Not a file</source>
-        <translation type="unfinished">Не файл</translation>
+        <translation>Это не файл</translation>
     </message>
     <message>
-        <source>The path was supposed to point to a file, but it doesn&apos;t</source>
-        <translation type="unfinished">Путь должен был указывать на файл, но это не так</translation>
+        <source>File not found</source>
+        <translation>Файл не найден</translation>
     </message>
     <message>
-        <source>Please remove the conflict and retry</source>
-        <translation type="unfinished">Пожалуйста, удалите конфликт и повторите</translation>
+        <source>File not readable</source>
+        <translation>Файл недоступен для чтения</translation>
     </message>
     <message>
-        <source>The database file is not readable</source>
-        <translation type="unfinished">Файл базы данных не читается</translation>
+        <source>File not writable</source>
+        <translation>Файл недоступен для записи</translation>
     </message>
     <message>
-        <source>Please set the proper permissions and retry
-If this error persists, please report this issue</source>
-        <translation type="unfinished">Пожалуйста, установите правильные разрешения и повторите
-Если эта ошибка сохраняется, пожалуйста, сообщите об этой проблеме</translation>
+        <source>File is empty</source>
+        <translation>Файл пуст</translation>
     </message>
     <message>
-        <source>The database file is not writable</source>
-        <translation type="unfinished">Файл базы данных не пишется</translation>
+        <source>Failed reading</source>
+        <translation>Ошибка при чтении</translation>
     </message>
     <message>
-        <source>Invalid database path</source>
-        <translation type="unfinished">Недействительный путь базы данных</translation>
+        <source>Not a folder</source>
+        <translation>Это не папка</translation>
+    </message>
+    <message>
+        <source>Directory not found</source>
+        <translation>Каталог не найден</translation>
+    </message>
+    <message>
+        <source>Directory not readable</source>
+        <translation>Каталог недоступен для чтения</translation>
+    </message>
+    <message>
+        <source>Directory not writable</source>
+        <translation>Каталог недоступен для записи</translation>
+    </message>
+    <message>
+        <source>Failed creating directory</source>
+        <translation>Ошибка при создании каталога</translation>
+    </message>
+    <message>
+        <source>QSql driver not found</source>
+        <translation>Драйвер QSql не найден</translation>
+    </message>
+    <message>
+        <source>Database created</source>
+        <translation>База данных создана</translation>
     </message>
     <message>
         <source>Failed creating database</source>
-        <translation type="unfinished">Не удалось создать базу данных</translation>
-    </message>
-    <message>
-        <source>An error occured while creating the database</source>
-        <translation type="unfinished">При создании базы данных произошла ошибка</translation>
+        <translation>Ошибка при создании базы данных</translation>
     </message>
     <message>
         <source>Failed opening database</source>
-        <translation type="unfinished">Не удалось открыть базу данных</translation>
-    </message>
-    <message>
-        <source>An error occured while opening the database</source>
-        <translation type="unfinished">Во время открытия базы данных произошла ошибка</translation>
+        <translation>Не удалось открыть базу данных</translation>
     </message>
     <message>
         <source>Failed executing on database</source>
-        <translation type="unfinished">Неудачная работа в базе данных</translation>
+        <translation>Ошибка выполнения операции с базой данных</translation>
     </message>
     <message>
-        <source>An error occured while executing a statement on the database</source>
-        <translation type="unfinished">Ошибка произошла при выполнении заявления в базе данных</translation>
+        <source>Unexpected table</source>
+        <translation>Неожиданная таблица</translation>
+    </message>
+    <message>
+        <source>Table not found</source>
+        <translation>Таблица не найдена</translation>
+    </message>
+    <message>
+        <source>Unexpected column</source>
+        <translation>Неожиданный столбец</translation>
+    </message>
+    <message>
+        <source>Column not found</source>
+        <translation>Столбец не найден</translation>
+    </message>
+    <message>
+        <source>Unexpected data-type</source>
+        <translation>Неожиданный тип данных</translation>
     </message>
     <message>
         <source>Failed to backup database</source>
-        <translation type="unfinished">Не удалось создать резервную базу данных</translation>
+        <translation>Ошибка создания резервной копии базы данных</translation>
     </message>
     <message>
-        <source>Please report this issue</source>
-        <translation type="unfinished">Пожалуйста, сообщите об этом вопросе</translation>
-    </message>
-    <message>
-        <source>Invalid log format string</source>
-        <translation type="unfinished">Недействительная строка формата log</translation>
-    </message>
-    <message>
-        <source>Please check that no error is thrown by your WebServer
-If it gets accepted, please check the presence of a typo here
-If everything is fine, please report this issue</source>
-        <translation type="unfinished">Пожалуйста, проверьте, что Ваш веб-сервер не ошибается.
-Если он будет принят, пожалуйста, проверьте наличие опечатки здесь
-Если все в порядке, пожалуйста, сообщите об этом</translation>
+        <source>Failed defining type</source>
+        <translation>Ошибка при определении типа</translation>
     </message>
     <message>
         <source>Log format error</source>
-        <translation type="unfinished">Ошибка формата</translation>
+        <translation>Ошибка формата журнала</translation>
+    </message>
+    <message>
+        <source>Misconfigured log format</source>
+        <translation>Некорректно настроен формат журнала</translation>
+    </message>
+    <message>
+        <source>Invalid log format string</source>
+        <translation>Недопустимая строка формата журнала</translation>
+    </message>
+    <message>
+        <source>File already used</source>
+        <translation>Файл уже используется</translation>
+    </message>
+    <message>
+        <source>File exceeds warning size</source>
+        <translation>Размер файла превышает порог предупреждения</translation>
+    </message>
+    <message>
+        <source>An error occured while renaming</source>
+        <translation>Произошла ошибка при переименовании</translation>
+    </message>
+    <message>
+        <source>Unexpected locale format</source>
+        <translation>Неожиданный формат локали</translation>
+    </message>
+    <message>
+        <source>The given locale is not an accepted language</source>
+        <translation>Указанная локаль не поддерживается</translation>
+    </message>
+    <message>
+        <source>An error occured while handling the configuration file</source>
+        <translation>Произошла ошибка при обработке конфигурационного файла</translation>
+    </message>
+    <message>
+        <source>Unable to retrieve the configuration file</source>
+        <translation>Не удалось получить конфигурационный файл</translation>
+    </message>
+    <message>
+        <source>Current configuration not saved</source>
+        <translation>Текущая конфигурация не сохранена</translation>
+    </message>
+    <message>
+        <source>An error occured while getting the help file</source>
+        <translation>Произошла ошибка при получении файла справки</translation>
+    </message>
+    <message>
+        <source>The path was supposed to point to a file, but it doesn&apos;t</source>
+        <translation>Ожидался путь к файлу, но это не так</translation>
+    </message>
+    <message>
+        <source>Unable to retrieve the file</source>
+        <translation>Не удалось получить файл</translation>
+    </message>
+    <message>
+        <source>The file is not readable</source>
+        <translation>Файл недоступен для чтения</translation>
+    </message>
+    <message>
+        <source>The file is not writable</source>
+        <translation>Файл недоступен для записи</translation>
+    </message>
+    <message>
+        <source>The file is blank</source>
+        <translation>Файл пуст</translation>
+    </message>
+    <message>
+        <source>The path was supposed to point to a folder, but it doesn&apos;t</source>
+        <translation>Ожидался путь к папке, но это не так</translation>
+    </message>
+    <message>
+        <source>The directory does not exists</source>
+        <translation>Каталог не существует</translation>
+    </message>
+    <message>
+        <source>The directory is not readable</source>
+        <translation>Каталог недоступен для чтения</translation>
+    </message>
+    <message>
+        <source>The directory is not writable</source>
+        <translation>Каталог недоступен для записи</translation>
+    </message>
+    <message>
+        <source>Failed to retrieve the database file</source>
+        <translation>Не удалось получить файл базы данных</translation>
+    </message>
+    <message>
+        <source>The database file is not readable</source>
+        <translation>Файл базы данных недоступен для чтения</translation>
+    </message>
+    <message>
+        <source>The database file is not writable</source>
+        <translation>Файл базы данных недоступен для записи</translation>
+    </message>
+    <message>
+        <source>Successfully created a new database</source>
+        <translation>Новая база данных успешно создана</translation>
+    </message>
+    <message>
+        <source>An error occured while creating the database</source>
+        <translation>Произошла ошибка при создании базы данных</translation>
+    </message>
+    <message>
+        <source>An error occured while opening the database</source>
+        <translation>Произошла ошибка при открытии базы данных</translation>
+    </message>
+    <message>
+        <source>An error occured while executing a statement on the database</source>
+        <translation>Произошла ошибка при выполнении запроса к базе данных</translation>
+    </message>
+    <message>
+        <source>The database contains an unexpected table</source>
+        <translation>База данных содержит неожиданную таблицу</translation>
+    </message>
+    <message>
+        <source>It seems that the database is missing a table</source>
+        <translation>Похоже, в базе данных отсутствует таблица</translation>
+    </message>
+    <message>
+        <source>It seems that the table is missing a column</source>
+        <translation>Похоже, в таблице отсутствует столбец</translation>
+    </message>
+    <message>
+        <source>The database contains an unexpected column</source>
+        <translation>База данных содержит неожиданный столбец</translation>
+    </message>
+    <message>
+        <source>A column has an unexpected data-type</source>
+        <translation>У столбца неожиданно неверный тип данных</translation>
+    </message>
+    <message>
+        <source>Failed to retrieve the selected file</source>
+        <translation>Не удалось получить выбранный файл</translation>
+    </message>
+    <message>
+        <source>The file has probably been used already</source>
+        <translation>Файл, вероятно, уже был использован</translation>
+    </message>
+    <message>
+        <source>The file&apos;s size exceeds the warning size</source>
+        <translation>Размер файла превышает допустимый лимит</translation>
+    </message>
+    <message>
+        <source>Failed to determine the log type</source>
+        <translation>Не удалось определить тип журнала</translation>
     </message>
     <message>
         <source>The log format has not been set, or is invalid
 Please add a valid one in the configurations</source>
-        <translation type="unfinished">Формат журнала не был установлен или является недействительным
-Пожалуйста, добавьте действительный в конфигурациях</translation>
-    </message>
-    <message>
-        <source>Misconfigured log format</source>
-        <translation type="unfinished">Неправильный формат журнала</translation>
+        <translation>Формат журнала не задан или некорректен  
+Пожалуйста, укажите правильный формат в настройках</translation>
     </message>
     <message>
         <source>No log field has been set in the current logs format,
 making it useless to parse logs</source>
-        <translation type="unfinished">В текущем формате журналов не установлено поле журнала,
-сделать бесполезным разбор бревен</translation>
-    </message>
-    <message>
-        <source>Please set up a format which contains at least one field</source>
-        <translation type="unfinished">Настройте формат, который содержит хотя бы одно поле</translation>
+        <translation>В текущем формате журнала не задано ни одного поля,  
+что делает невозможным разбор логов</translation>
     </message>
     <message>
         <source>A separator is missing between one or more fields,
 making it hard to establish net bounds,
 and possibly leading to store incorrect data</source>
-        <translation type="unfinished">Отсутствует разделитель между одним или несколькими полями.
-Чтобы затруднить установление границ сети,
-и, возможно, приводит к хранению неправильных данных</translation>
+        <translation>Между полями отсутствует разделитель,  
+что затрудняет определение границ и может привести к ошибкам в данных</translation>
     </message>
     <message>
-        <source>Please set up a format which contains separators between fields</source>
-        <translation type="unfinished">Настройте формат, который содержит разделители между полями</translation>
+        <source>Please report this issue</source>
+        <translation>Пожалуйста, сообщите об этой ошибке</translation>
     </message>
     <message>
-        <source>Missing field in log format</source>
-        <translation type="unfinished">Пропавшее поле в формате журнала</translation>
-    </message>
-    <message>
-        <source>An important field is missing from the provided format:</source>
-        <translation type="unfinished">В представленном формате отсутствует важное поле:</translation>
-    </message>
-    <message>
-        <source>The quality of the statistics may be seriously compromized</source>
-        <translation type="unfinished">Качество статистики может быть серьезно поставлено под угрозу</translation>
-    </message>
-    <message>
-        <source>Proceed anyway?</source>
-        <translation type="unfinished">В любом случае?</translation>
-    </message>
-    <message>
-        <source>&apos;Carriage Return&apos; in log format</source>
-        <translation type="unfinished">«Возвращение груза» в формате log</translation>
-    </message>
-    <message>
-        <source>The provided format contains the &apos;Carriage Return&apos;.
-This may lead to data losses or crashes if not used with caution</source>
-        <translation type="unfinished">Предоставляемый формат содержит «Возвращение перевозки».
-Это может привести к потере данных или сбоям, если не использовать с осторожностью</translation>
-    </message>
-    <message>
-        <source>An error occured while parsing logs</source>
-        <translation type="unfinished">Произошла ошибка при разборе журналов</translation>
-    </message>
-    <message>
-        <source>Failed defining type</source>
-        <translation type="unfinished">Неудачный тип определения</translation>
-    </message>
-    <message>
-        <source>Failed to determine the log type</source>
-        <translation type="unfinished">Не удалось определить тип журнала</translation>
-    </message>
-    <message>
-        <source>File already used</source>
-        <translation type="unfinished">Файл уже используется</translation>
-    </message>
-    <message>
-        <source>The file has probably been used already</source>
-        <translation type="unfinished">Файл, вероятно, уже использовался</translation>
-    </message>
-    <message>
-        <source>Ignore the warning and use it anyway, Discard it and continue, or Abort the entire process?</source>
-        <translation type="unfinished">Игнорировать предупреждение и использовать его в любом случае, отбросить его и продолжить, или прервать весь процесс?</translation>
-    </message>
-    <message>
-        <source>Duplicate file</source>
-        <translation type="unfinished">Дублированный файл</translation>
-    </message>
-    <message>
-        <source>The file appears twice in the list of selections</source>
-        <translation type="unfinished">Файл появляется дважды в списке выбора</translation>
-    </message>
-    <message>
-        <source>Failed updating hashes</source>
-        <translation type="unfinished">Неудачные обновления хешей</translation>
-    </message>
-    <message>
-        <source>An error occured while inserting the parsed files hashes into the database</source>
-        <translation type="unfinished">Произошла ошибка при вставке хешей парсированных файлов в базу данных</translation>
-    </message>
-    <message>
-        <source>File exceeds warning size</source>
-        <translation type="unfinished">Файл превышает размер предупреждения</translation>
-    </message>
-    <message>
-        <source>The file&apos;s size exceeds the warning size</source>
-        <translation type="unfinished">Размер файла превышает размер предупреждения</translation>
-    </message>
-    <message>
-        <source>Not enough memory</source>
-        <translation type="unfinished">Недостаточно памяти</translation>
-    </message>
-    <message>
-        <source>The total size of the selected files exceeds the available memory</source>
-        <translation type="unfinished">Общий размер выбранных файлов превышает доступную память</translation>
-    </message>
-    <message>
-        <source>Please free some resources, parse the files in different steps or split them into smaller units</source>
-        <translation type="unfinished">Пожалуйста, освободите некоторые ресурсы, разберите файлы в разных шагах или разделите их на более мелкие блоки</translation>
-    </message>
-    <message>
-        <source>Failed reading</source>
-        <translation type="unfinished">Неудачное чтение</translation>
-    </message>
-    <message>
-        <source>File is empty</source>
-        <translation type="unfinished">Файл пустой</translation>
-    </message>
-    <message>
-        <source>The file is blank</source>
-        <translation type="unfinished">Файл пустой</translation>
-    </message>
-    <message>
-        <source>Failed to retrieve the selected file</source>
-        <translation type="unfinished">Не удалось восстановить выбранный файл</translation>
-    </message>
-    <message>
-        <source>Discard it and continue, or Abort all and exit?</source>
-        <translation type="unfinished">Откажитесь от него и продолжайте, или прекратите все и уходите?</translation>
-    </message>
-    <message>
-        <source>No file to parse</source>
-        <translation type="unfinished">Нет файла для анализа</translation>
-    </message>
-    <message>
-        <source>The list of files to parse is empty</source>
-        <translation type="unfinished">Список файлов для разбора пуст</translation>
-    </message>
-    <message>
-        <source>Directory not found</source>
-        <translation type="unfinished">Директория не найдена</translation>
-    </message>
-    <message>
-        <source>The directory does not exists</source>
-        <translation type="unfinished">Каталог не существует</translation>
-    </message>
-    <message>
-        <source>Directory not readable</source>
-        <translation type="unfinished">Директория нечитаемая</translation>
-    </message>
-    <message>
-        <source>The directory is not readable</source>
-        <translation type="unfinished">Каталог не читается</translation>
+        <source>Please remove the conflict and retry</source>
+        <translation>Устраните конфликт и повторите попытку</translation>
     </message>
     <message>
         <source>Please set the proper permissions before to start</source>
-        <translation type="unfinished">Пожалуйста, установите соответствующие разрешения перед началом</translation>
+        <translation>Установите необходимые права доступа перед запуском</translation>
     </message>
     <message>
-        <source>Failed creating directory</source>
-        <translation type="unfinished">Не удалось создать каталог</translation>
+        <source>Please set the proper permissions and retry
+If this error persists, please report this issue</source>
+        <translation>Установите правильные разрешения и повторите попытку  
+Если ошибка повторяется — сообщите о проблеме</translation>
     </message>
     <message>
-        <source>The path does not exists</source>
-        <translation type="unfinished">Путь не существует</translation>
+        <source>If you haven&apos;t manually edited the configuration file,
+please report this issue</source>
+        <translation>Если вы не редактировали конфигурационный файл вручную,  
+пожалуйста, сообщите об этой ошибке</translation>
     </message>
     <message>
-        <source>Data conversion failed</source>
-        <translation type="unfinished">Конверсия данных провалилась</translation>
+        <source>Please set up a format which contains at least one field</source>
+        <translation>Укажите формат, содержащий хотя бы одно поле</translation>
     </message>
     <message>
-        <source>Failed to convert from &apos;%1&apos; to &apos;%2&apos;</source>
-        <translation type="unfinished">Не удалось конвертировать из «%1» в «%2»</translation>
+        <source>Please set up a format which contains separators between fields</source>
+        <translation>Укажите формат с разделителями между полями</translation>
     </message>
     <message>
-        <source>Failed to create statistics</source>
-        <translation type="unfinished">Не удалось создать статистику</translation>
+        <source>Skipping</source>
+        <translation>Пропускаем</translation>
     </message>
     <message>
-        <source>An error occured while processing</source>
-        <translation type="unfinished">Ошибка, возникшая при обработке</translation>
+        <source>Aborting</source>
+        <translation>Прерывание</translation>
     </message>
     <message>
-        <source>Cannot create statistics</source>
-        <translation type="unfinished">Невозможно создать статистику</translation>
+        <source>Additional resources can be downloaded from the git repo</source>
+        <translation>Дополнительные ресурсы можно скачать из репозитория Git</translation>
     </message>
     <message>
-        <source>No data has been found that matches with the currently set parameters</source>
-        <translation type="unfinished">Не найдено данных, которые соответствовали бы установленным в настоящее время параметрам</translation>
+        <source>An error occured while parsing the format string</source>
+        <translation>Произошла ошибка при разборе строки формата</translation>
     </message>
     <message>
-        <source>Not a folder</source>
-        <translation type="unfinished">Не папка</translation>
+        <source>Size of the file</source>
+        <translation>Размер файла</translation>
     </message>
     <message>
-        <source>The path was supposed to point to a folder, but it doesn&apos;t</source>
-        <translation type="unfinished">Путь должен был указывать на папку, но это не так</translation>
+        <source>Warning size parameter</source>
+        <translation>Порог предупреждения по размеру</translation>
+    </message>
+    <message>
+        <source>Something failed while handling the file</source>
+        <translation>Произошла ошибка при обработке файла</translation>
+    </message>
+    <message>
+        <source>An error occured while working on the database</source>
+        <translation>Произошла ошибка при работе с базой данных</translation>
+    </message>
+    <message>
+        <source>One of the lists has an invalid item</source>
+        <translation>Один из элементов списка недопустим</translation>
+    </message>
+    <message>
+        <source>Failed to write the configuration file</source>
+        <translation>Ошибка при записи конфигурационного файла</translation>
+    </message>
+    <message>
+        <source>Failed applying configuration</source>
+        <translation>Ошибка при применении конфигурации</translation>
+    </message>
+    <message>
+        <source>Invalid string</source>
+        <translation>Неверная строка</translation>
+    </message>
+    <message>
+        <source>The given string is invalid and cannot be added to the list
+
+Please correct it and retry</source>
+        <translation>Указанная строка недопустима и не может быть добавлена в список  
+Исправьте её и повторите попытку</translation>
+    </message>
+    <message>
+        <source>Please check that no error is thrown by your WebServer
+If it gets accepted, please check the presence of a typo here
+If everything is fine, please report this issue</source>
+        <translation>Убедитесь, что ваш веб-сервер не возвращает ошибку  
+Если всё в порядке, проверьте наличие опечаток  
+Если проблема сохраняется — сообщите об ошибке</translation>
+    </message>
+    <message>
+        <source>An error occured while parsing logs</source>
+        <translation>Произошла ошибка при разборе логов</translation>
+    </message>
+    <message>
+        <source>Ignore the warning and use it anyway, Discard it and continue, or Abort the entire process?</source>
+        <translation>Игнорировать предупреждение и использовать всё равно, отклонить и продолжить или прервать весь процесс?</translation>
+    </message>
+    <message>
+        <source>Proceed anyway?</source>
+        <translation>Всё равно продолжить?</translation>
+    </message>
+    <message>
+        <source>If you&apos;d like to have this locale in LogDoctor,
+please follow the instruction on the repository page</source>
+        <translation>Если вы хотите добавить эту локаль в LogDoctor,  
+пожалуйста, следуйте инструкциям на странице репозитория</translation>
+    </message>
+    <message>
+        <source>Failed to create the directory</source>
+        <translation>Не удалось создать каталог</translation>
+    </message>
+    <message>
+        <source>Unrecognized entry</source>
+        <translation>Неопознанная запись</translation>
+    </message>
+    <message>
+        <source>Duplicate file</source>
+        <translation>Повторяющийся файл</translation>
+    </message>
+    <message>
+        <source>The file appears twice in the list of selections</source>
+        <translation>Файл указан дважды в списке выбора</translation>
+    </message>
+    <message>
+        <source>The list of files to parse is empty</source>
+        <translation>Список файлов для разбора пуст</translation>
+    </message>
+    <message>
+        <source>No file to parse</source>
+        <translation>Нет файлов для разбора</translation>
+    </message>
+    <message>
+        <source>Available memory</source>
+        <translation>Доступная память</translation>
+    </message>
+    <message>
+        <source>Size of the logs</source>
+        <translation>Объём логов</translation>
+    </message>
+    <message>
+        <source>Not enough memory</source>
+        <translation>Недостаточно памяти</translation>
+    </message>
+    <message>
+        <source>The total size of the selected files exceeds the available memory</source>
+        <translation>Общий размер выбранных файлов превышает доступную память</translation>
+    </message>
+    <message>
+        <source>Please free some resources, parse the files in different steps or split them into smaller units</source>
+        <translation>Освободите ресурсы, разбейте файлы на части или обрабатывайте их поэтапно</translation>
+    </message>
+    <message>
+        <source>This database will be renamed with a trailing &apos;.copy&apos; and a new one will be created.
+Continue?</source>
+        <translation>Эта база данных будет переименована с добавлением «.copy», и будет создана новая.  
+Продолжить?</translation>
+    </message>
+    <message>
+        <source>An error occured while reading the file</source>
+        <translation>Произошла ошибка при чтении файла</translation>
     </message>
     <message>
         <source>The entry will be renamed with a trailing &apos;.copy&apos; and a new one will be created.
 Continue?</source>
-        <translation type="unfinished">Запись будет переименована в «.copy» и будет создана новая.
-Продолжай?</translation>
+        <translation>Запись будет переименована с добавлением «.copy», и будет создана новая.  
+Продолжить?</translation>
     </message>
     <message>
-        <source>An error occured</source>
-        <translation type="unfinished">Произошла ошибка</translation>
+        <source>An error occured while reading the gzipped file</source>
+        <translation>Произошла ошибка при чтении сжатого файла (gzip)</translation>
     </message>
     <message>
-        <source>Failed renaming</source>
-        <translation type="unfinished">Неудавшееся переименование</translation>
+        <source>Invalid configuration lines</source>
+        <translation>Недопустимые строки конфигурации</translation>
     </message>
     <message>
-        <source>An error occured while renaming</source>
-        <translation type="unfinished">Произошла ошибка при переименовании</translation>
+        <source>Has not been possible to apply some of the configurations</source>
+        <translation>Некоторые конфигурации не удалось применить</translation>
+    </message>
+    <message>
+        <source>If you choose to proceed, all of the unapplied configurations will be lost
+Continue?</source>
+        <translation>Если вы продолжите, все неприменённые конфигурации будут утеряны.  
+Продолжить?</translation>
+    </message>
+    <message>
+        <source>Failed to retrieve the driver needed to handle the database</source>
+        <translation>Не удалось получить драйвер для работы с базой данных</translation>
+    </message>
+    <message>
+        <source>Failed updating hashes</source>
+        <translation>Ошибка при обновлении хэшей</translation>
+    </message>
+    <message>
+        <source>An error occured while inserting the parsed files hashes into the database</source>
+        <translation>Произошла ошибка при добавлении хэшей разобранных файлов в базу данных</translation>
+    </message>
+    <message>
+        <source>Data conversion failed</source>
+        <translation>Ошибка преобразования данных</translation>
+    </message>
+    <message>
+        <source>Failed to convert from &apos;%1&apos; to &apos;%2&apos;</source>
+        <translation>Не удалось преобразовать из «%1» в «%2»</translation>
+    </message>
+    <message>
+        <source>Failed to create statistics</source>
+        <translation>Не удалось создать статистику</translation>
+    </message>
+    <message>
+        <source>An error occured while processing</source>
+        <translation>Произошла ошибка при обработке</translation>
+    </message>
+    <message>
+        <source>Cannot create statistics</source>
+        <translation>Невозможно создать статистику</translation>
+    </message>
+    <message>
+        <source>No data has been found that matches with the currently set parameters</source>
+        <translation>Не найдено данных, соответствующих текущим параметрам</translation>
+    </message>
+    <message>
+        <source>Missing field in log format</source>
+        <translation>Отсутствует поле в формате журнала</translation>
+    </message>
+    <message>
+        <source>An important field is missing from the provided format:</source>
+        <translation>Во входном формате отсутствует важное поле:</translation>
+    </message>
+    <message>
+        <source>The quality of the statistics may be seriously compromized</source>
+        <translation>Качество статистики может быть существенно снижено</translation>
+    </message>
+    <message>
+        <source>&apos;Carriage Return&apos; in log format</source>
+        <translation>Символ возврата каретки в формате журнала</translation>
+    </message>
+    <message>
+        <source>The provided format contains the &apos;Carriage Return&apos;.
+This may lead to data losses or crashes if not used with caution</source>
+        <translation>Указанный формат содержит символ возврата каретки.  
+Это может привести к потере данных или сбоям при неправильном использовании</translation>
+    </message>
+    <message>
+        <source>Failed to create the configuration file</source>
+        <translation>Не удалось создать конфигурационный файл</translation>
+    </message>
+    <message>
+        <source>The path contains a symlink</source>
+        <translation>Путь содержит символическую ссылку</translation>
+    </message>
+    <message>
+        <source>The file does not exist</source>
+        <translation>Файл не существует</translation>
+    </message>
+    <message>
+        <source>Invalid path</source>
+        <translation>Недопустимый путь</translation>
+    </message>
+    <message>
+        <source>Invalid database path</source>
+        <translation>Недопустимый путь к базе данных</translation>
+    </message>
+    <message>
+        <source>The path does not exists</source>
+        <translation>Указанный путь не существует</translation>
     </message>
 </context>
 <context>
     <name>GameDialog</name>
     <message>
         <source>Ok</source>
-        <translation type="unfinished">Хорошо</translation>
+        <translation>Ок</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
         <source>Parse logs from the Apache2 web server</source>
-        <translation type="unfinished">Парсовые журналы с веб-сервера Apache2</translation>
-    </message>
-    <message>
-        <source>Apache2</source>
-        <translation type="unfinished">Apache2</translation>
+        <translation>Разбор логов с веб-сервера Apache2</translation>
     </message>
     <message>
         <source>Parse logs from the Nginx web server</source>
-        <translation type="unfinished">Парсовые журналы с веб-сервера Nginx</translation>
-    </message>
-    <message>
-        <source>Nginx</source>
-        <translation type="unfinished">Nginx</translation>
+        <translation>Разбор логов с веб-сервера Nginx</translation>
     </message>
     <message>
         <source>Parse logs from the Microsoft IIS web server</source>
-        <translation type="unfinished">Парсовые журналы с веб-сервера Microsoft IIS</translation>
-    </message>
-    <message>
-        <source>IIS</source>
-        <translation type="unfinished">IIS</translation>
-    </message>
-    <message>
-        <source>Select/deselect all the files</source>
-        <translation type="unfinished">Выберите / выберите все файлы</translation>
+        <translation>Разбор логов с веб-сервера Microsoft IIS</translation>
     </message>
     <message>
         <source>All</source>
-        <translation type="unfinished">Все</translation>
+        <translation>Все</translation>
     </message>
     <message>
         <source>Inspect a log file</source>
-        <translation type="unfinished">Проверьте файл log</translation>
+        <translation>Просмотреть файл лога</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished">Имя</translation>
+        <translation>Имя</translation>
     </message>
     <message>
         <source>Size</source>
-        <translation type="unfinished">Размер</translation>
+        <translation>Размер</translation>
     </message>
     <message>
         <source>Refresh the list</source>
-        <translation type="unfinished">Обновить список</translation>
+        <translation>Обновить список</translation>
     </message>
     <message>
         <source>Total size of the parsed data</source>
-        <translation type="unfinished">Общий размер парсированных данных</translation>
+        <translation>Общий размер обработанных данных</translation>
     </message>
     <message>
         <source>Total number of parsed lines</source>
-        <translation type="unfinished">Общее количество парированных линий</translation>
+        <translation>Общее количество обработанных строк</translation>
     </message>
     <message>
         <source>Start parsing the selected files</source>
-        <translation type="unfinished">Начните анализ выбранных файлов</translation>
+        <translation>Начать разбор выбранных файлов</translation>
     </message>
     <message>
         <source>START</source>
-        <translation type="unfinished">Начать</translation>
-    </message>
-    <message>
-        <source>Time elapsed since the start</source>
-        <translation type="unfinished">Время истекло с самого начала</translation>
-    </message>
-    <message>
-        <source>Average speed, in parsed data size per second</source>
-        <translation type="unfinished">Средняя скорость, в разреженном размере данных в секунду</translation>
-    </message>
-    <message>
-        <source>Web Server</source>
-        <translation type="unfinished">Веб-сервер</translation>
-    </message>
-    <message>
-        <source>Select a Web Server</source>
-        <translation type="unfinished">Выберите веб-сервер</translation>
-    </message>
-    <message>
-        <source>Year</source>
-        <translation type="unfinished">Год</translation>
-    </message>
-    <message>
-        <source>Month</source>
-        <translation type="unfinished">месяц</translation>
-    </message>
-    <message>
-        <source>Day</source>
-        <translation type="unfinished">День</translation>
-    </message>
-    <message>
-        <source>Hour</source>
-        <translation type="unfinished">Час</translation>
-    </message>
-    <message>
-        <source>Draw the chart</source>
-        <translation type="unfinished">Нарисуйте график</translation>
-    </message>
-    <message>
-        <source>Log line marked as Warning</source>
-        <translation type="unfinished">Логическая линия, обозначенная как предупреждение</translation>
-    </message>
-    <message>
-        <source>Date when the request arrived (YYYY-MM-DD)</source>
-        <translation type="unfinished">Дата прибытия запроса (YYYY-MM-DD)</translation>
-    </message>
-    <message>
-        <source>Time when the request arrived (hh:mm:ss)</source>
-        <translation type="unfinished">Время, когда поступил запрос (hh:mm:ss)</translation>
-    </message>
-    <message>
-        <source>Protocol of the request</source>
-        <translation type="unfinished">Протокол просьбы</translation>
-    </message>
-    <message>
-        <source>Method of the request</source>
-        <translation type="unfinished">Способ подачи просьбы</translation>
-    </message>
-    <message>
-        <source>URI of the requested page</source>
-        <translation type="unfinished">URI запрашиваемой страницы</translation>
-    </message>
-    <message>
-        <source>Query carried along with the URI</source>
-        <translation type="unfinished">Запрос, выполненный вместе с URI</translation>
-    </message>
-    <message>
-        <source>Response code from the server</source>
-        <translation type="unfinished">Код ответа с сервера</translation>
-    </message>
-    <message>
-        <source>User-agent of the client which made the request</source>
-        <translation type="unfinished">Пользователь-агент клиента, который сделал запрос</translation>
-    </message>
-    <message>
-        <source>IP address of the Client which made the request</source>
-        <translation type="unfinished">IP-адрес Клиента, который сделал запрос</translation>
-    </message>
-    <message>
-        <source>Cookie used for the request</source>
-        <translation type="unfinished">Cookies, используемые для запроса</translation>
-    </message>
-    <message>
-        <source>The URL which redirected the Client to the requested page</source>
-        <translation type="unfinished">URL, который перенаправил клиента на запрашиваемую страницу</translation>
-    </message>
-    <message>
-        <source>Size ib Bytes of the request, usually includes header and data</source>
-        <translation type="unfinished">Размер ib байтов запроса, обычно включает в себя заголовок и данные</translation>
-    </message>
-    <message>
-        <source>Size in Bytes of the served content, usually includes header and data</source>
-        <translation type="unfinished">Размер в байтах обслуживаемого контента, обычно включает заголовок и данные</translation>
-    </message>
-    <message>
-        <source>Time taken by the server to serve the content, in milliseconds</source>
-        <translation type="unfinished">Время, затрачиваемое сервером на обслуживание контента, в миллисекундах</translation>
-    </message>
-    <message>
-        <source>Only use lines in which the field is starting with this string</source>
-        <translation type="unfinished">Используйте только линии, в которых поле начинается с этой строки</translation>
-    </message>
-    <message>
-        <source>Protocol:</source>
-        <translation type="unfinished">Протокол:</translation>
-    </message>
-    <message>
-        <source>Method:</source>
-        <translation type="unfinished">Метод:</translation>
-    </message>
-    <message>
-        <source>Only use lines in which the field is matching this statement.
-Use &apos;!&apos;, &apos;=&apos;,&apos;&lt;&apos; or &apos;&gt;&apos; to declare what to use</source>
-        <translation type="unfinished">Используйте только линии, в которых поле соответствует этому утверждению.
-Используйте «!», «=», «&lt;» или «&gt;», чтобы указать, что использовать</translation>
-    </message>
-    <message>
-        <source>Response:</source>
-        <translation type="unfinished">Ответ:</translation>
-    </message>
-    <message>
-        <source>Query:</source>
-        <translation type="unfinished">Вопрос:</translation>
-    </message>
-    <message>
-        <source>URI:</source>
-        <translation type="unfinished">УРИ:</translation>
-    </message>
-    <message>
-        <source>Filters</source>
-        <translation type="unfinished">Фильтры</translation>
-    </message>
-    <message>
-        <source>Count</source>
-        <translation type="unfinished">граф</translation>
-    </message>
-    <message>
-        <source>Number of occurrences</source>
-        <translation type="unfinished">Количество происшествий</translation>
-    </message>
-    <message>
-        <source>Item</source>
-        <translation type="unfinished">Пункт</translation>
-    </message>
-    <message>
-        <source>Value of the field</source>
-        <translation type="unfinished">Значение поля</translation>
-    </message>
-    <message>
-        <source>From:</source>
-        <translation type="unfinished">Из:</translation>
-    </message>
-    <message>
-        <source>To:</source>
-        <translation type="unfinished">Для:</translation>
-    </message>
-    <message>
-        <source>Select a log field to view</source>
-        <translation type="unfinished">Выберите поле log для просмотра</translation>
-    </message>
-    <message>
-        <source>Field:</source>
-        <translation type="unfinished">Поле:</translation>
-    </message>
-    <message>
-        <source>Filter:</source>
-        <translation type="unfinished">Фильтр:</translation>
-    </message>
-    <message>
-        <source>With strings, only the lines in which the field is starting with this string will be used.
-With numbers, use &apos;!&apos;, &apos;=&apos;,&apos;&lt;&apos; or &apos;&gt;&apos; to declare what to use</source>
-        <translation type="unfinished">При струнах будут использоваться только линии, в которых поле начинается с этой струны.
-С цифрами используйте «!», «=», «&lt;» или «&gt;», чтобы объявить, что использовать</translation>
-    </message>
-    <message>
-        <source>Protocol</source>
-        <translation type="unfinished">Протокол</translation>
-    </message>
-    <message>
-        <source>Method</source>
-        <translation type="unfinished">метод</translation>
-    </message>
-    <message>
-        <source>URI</source>
-        <translation type="unfinished">Ури</translation>
-    </message>
-    <message>
-        <source>User-agent</source>
-        <translation type="unfinished">Агент-пользователь</translation>
-    </message>
-    <message>
-        <source>Most recurrent</source>
-        <translation type="unfinished">Самый повторяющийся</translation>
-    </message>
-    <message>
-        <source>Most trafficked</source>
-        <translation type="unfinished">Большинство из них</translation>
-    </message>
-    <message>
-        <source>Date ever</source>
-        <translation type="unfinished">Свидание всегда</translation>
-    </message>
-    <message>
-        <source>Day of the week</source>
-        <translation type="unfinished">День недели</translation>
-    </message>
-    <message>
-        <source>Hour of the day</source>
-        <translation type="unfinished">Час дня</translation>
-    </message>
-    <message>
-        <source>Time taken</source>
-        <translation type="unfinished">Время</translation>
-    </message>
-    <message>
-        <source>Bytes sent</source>
-        <translation type="unfinished">отправленные байты</translation>
-    </message>
-    <message>
-        <source>Bytes received</source>
-        <translation type="unfinished">Полученные байты</translation>
-    </message>
-    <message>
-        <source>Mean/Max performances</source>
-        <translation type="unfinished">Средние/макс-выступления</translation>
-    </message>
-    <message>
-        <source>Requests received</source>
-        <translation type="unfinished">Полученные просьбы</translation>
-    </message>
-    <message>
-        <source>Total work</source>
-        <translation type="unfinished">Общая работа</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation type="unfinished">Генерал</translation>
-    </message>
-    <message>
-        <source>Window</source>
-        <translation type="unfinished">окно</translation>
-    </message>
-    <message>
-        <source>Dialogs</source>
-        <translation type="unfinished">Диалоги</translation>
-    </message>
-    <message>
-        <source>Charts</source>
-        <translation type="unfinished">диаграммы</translation>
-    </message>
-    <message>
-        <source>Appearance</source>
-        <translation type="unfinished">внешний вид</translation>
-    </message>
-    <message>
-        <source>Speed</source>
-        <translation type="unfinished">Скорость</translation>
-    </message>
-    <message>
-        <source>Relational</source>
-        <translation type="unfinished">относительный</translation>
-    </message>
-    <message>
-        <source>TextBrowser</source>
-        <translation type="unfinished">TextBrowser</translation>
-    </message>
-    <message>
-        <source>Databases</source>
-        <translation type="unfinished">Базы данных</translation>
-    </message>
-    <message>
-        <source>Security</source>
-        <translation type="unfinished">Безопасность</translation>
-    </message>
-    <message>
-        <source>Logs</source>
-        <translation type="unfinished">Лог</translation>
-    </message>
-    <message>
-        <source>Defaults</source>
-        <translation type="unfinished">недостатки</translation>
-    </message>
-    <message>
-        <source>Control</source>
-        <translation type="unfinished">Контроль</translation>
-    </message>
-    <message>
-        <source>Path</source>
-        <translation type="unfinished">Путь</translation>
-    </message>
-    <message>
-        <source>Format</source>
-        <translation type="unfinished">Формат</translation>
-    </message>
-    <message>
-        <source>Warnlists</source>
-        <translation type="unfinished">Списки предупреждений</translation>
-    </message>
-    <message>
-        <source>Blacklists</source>
-        <translation type="unfinished">Черные списки</translation>
-    </message>
-    <message>
-        <source>Remember the window&apos;s position and size</source>
-        <translation type="unfinished">Запомните положение и размер окна</translation>
-    </message>
-    <message>
-        <source>Remember position and size</source>
-        <translation type="unfinished">Запомните положение и размер</translation>
-    </message>
-    <message>
-        <source>Remember window&apos;s position and size</source>
-        <translation type="unfinished">Запомните положение и размер окна</translation>
-    </message>
-    <message>
-        <source>Geometry</source>
-        <translation type="unfinished">Геометрия</translation>
-    </message>
-    <message>
-        <source>Theme to use for the window</source>
-        <translation type="unfinished">Тема для использования в окне</translation>
-    </message>
-    <message>
-        <source>Theme</source>
-        <translation type="unfinished">Тема</translation>
-    </message>
-    <message>
-        <source>Native</source>
-        <translation type="unfinished">коренной</translation>
-    </message>
-    <message>
-        <source>Light</source>
-        <translation type="unfinished">Свет</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished">темный</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished">Автомат</translation>
-    </message>
-    <message>
-        <source>Icons</source>
-        <translation type="unfinished">Иконы</translation>
-    </message>
-    <message>
-        <source>Normal quantity of dialog messages shown</source>
-        <translation type="unfinished">Нормальное количество диалоговых сообщений</translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished">нормальный</translation>
-    </message>
-    <message>
-        <source>Dialogs from the main processes</source>
-        <translation type="unfinished">Диалоги основных процессов</translation>
-    </message>
-    <message>
-        <source>Dialogs emitted when parsing logs</source>
-        <translation type="unfinished">Диалоги, излучаемые при разборе журналов</translation>
-    </message>
-    <message>
-        <source>Logs parser</source>
-        <translation type="unfinished">Парсер журналов</translation>
-    </message>
-    <message>
-        <source>Dialogs emitted when viewing statistics</source>
-        <translation type="unfinished">Диалоги, излучаемые при просмотре статистики</translation>
-    </message>
-    <message>
-        <source>Statistics viewer</source>
-        <translation type="unfinished">Зритель статистики</translation>
-    </message>
-    <message>
-        <source>Define the quantity of dialog mesages shown</source>
-        <translation type="unfinished">Определите количество показанных диалоговых сообщений</translation>
-    </message>
-    <message>
-        <source>Dialogs level</source>
-        <translation type="unfinished">Диалог уровня</translation>
-    </message>
-    <message>
-        <source>Reduced quantity of dialog messages shown</source>
-        <translation type="unfinished">Уменьшение количества диалоговых сообщений</translation>
-    </message>
-    <message>
-        <source>Essential</source>
-        <translation type="unfinished">необходимый</translation>
-    </message>
-    <message>
-        <source>Augmented quantity of dialog messages shown</source>
-        <translation type="unfinished">Увеличенное количество диалоговых сообщений</translation>
-    </message>
-    <message>
-        <source>Explanatory</source>
-        <translation type="unfinished">пояснения</translation>
-    </message>
-    <message>
-        <source>Theme to use for the Charts</source>
-        <translation type="unfinished">Тема для использования в картах</translation>
-    </message>
-    <message>
-        <source>Preview</source>
-        <translation type="unfinished">Предварительный просмотр</translation>
-    </message>
-    <message>
-        <source>Represents a step in the time axis, in seconds.
-All the values falling inside the same interval will be merged and the mean value will be used.</source>
-        <translation type="unfinished">Представляет собой шаг в оси времени, в секундах.
-Все значения, попадающие в один и тот же интервал, будут объединены, и будет использоваться среднее значение.</translation>
-    </message>
-    <message>
-        <source>Time interval</source>
-        <translation type="unfinished">интервал времени</translation>
-    </message>
-    <message>
-        <source>The format to use for the labels of the time axis.</source>
-        <translation type="unfinished">Формат для использования для меток оси времени.</translation>
-    </message>
-    <message>
-        <source>Time format</source>
-        <translation type="unfinished">Формат времени</translation>
-    </message>
-    <message>
-        <source>The size of the pie</source>
-        <translation type="unfinished">Размеры пирога</translation>
-    </message>
-    <message>
-        <source>Pie size</source>
-        <translation type="unfinished">Размер пирога</translation>
-    </message>
-    <message>
-        <source>The maximum number of slices that the pie will be composed of.
-Exceeding slices will be grouped into one comprehensive slice.</source>
-        <translation type="unfinished">Максимальное количество ломтиков, из которых будет состоять пирог.
-Превышение ломтиков будет сгруппировано в один полный ломтик.</translation>
-    </message>
-    <message>
-        <source>Maximum slices</source>
-        <translation type="unfinished">Максимальные ломтики</translation>
-    </message>
-    <message>
-        <source>Font to use for the Text Browser</source>
-        <translation type="unfinished">Шрифт для использования в текстовом браузере</translation>
-    </message>
-    <message>
-        <source>Font</source>
-        <translation type="unfinished">шрифт</translation>
-    </message>
-    <message>
-        <source>Double-spaced lines</source>
-        <translation type="unfinished">Двухместные линии</translation>
-    </message>
-    <message>
-        <source>Use wide lines</source>
-        <translation type="unfinished">Используйте широкие линии</translation>
-    </message>
-    <message>
-        <source>Define the spacing between lines</source>
-        <translation type="unfinished">Определите расстояние между линиями</translation>
-    </message>
-    <message>
-        <source>Lines spacing</source>
-        <translation type="unfinished">Расстояние между линиями</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation type="unfinished">Никто</translation>
-    </message>
-    <message>
-        <source>Color scheme to use for the Text Browser</source>
-        <translation type="unfinished">Цветовая схема для использования в текстовом браузере</translation>
-    </message>
-    <message>
-        <source>Color scheme</source>
-        <translation type="unfinished">Цветовая схема</translation>
-    </message>
-    <message>
-        <source>The appearance of the Text Browser with the current settings</source>
-        <translation type="unfinished">Появление текстового браузера с текущими настройками</translation>
-    </message>
-    <message>
-        <source>Insert the base path only, file name excluded</source>
-        <translation type="unfinished">Вставьте только базовый путь, имя файла исключено</translation>
-    </message>
-    <message>
-        <source>The given path doen&apos;t exists, or doesn&apos;t point to a folder</source>
-        <translation type="unfinished">Данный путь не существует или не указывает на папку</translation>
-    </message>
-    <message>
-        <source>Path for the database files</source>
-        <translation type="unfinished">Путь к файлам базы данных</translation>
-    </message>
-    <message>
-        <source>Paths</source>
-        <translation type="unfinished">Пути</translation>
-    </message>
-    <message>
-        <source>Apply the current path</source>
-        <translation type="unfinished">Используйте текущий путь</translation>
-    </message>
-    <message>
-        <source>Select the path through a dialog window</source>
-        <translation type="unfinished">Выберите путь через диалоговое окно</translation>
-    </message>
-    <message>
-        <source>Path where the logs data collection database is located</source>
-        <translation type="unfinished">Путь, по которому находится база данных сбора логов</translation>
-    </message>
-    <message>
-        <source>Logs data</source>
-        <translation type="unfinished">Логи данных</translation>
-    </message>
-    <message>
-        <source>Path where the used files hashes database is located</source>
-        <translation type="unfinished">Путь, по которому расположена используемая база данных хешей файлов</translation>
-    </message>
-    <message>
-        <source>Used files</source>
-        <translation type="unfinished">Используемые файлы</translation>
-    </message>
-    <message>
-        <source>Backup options for the Logs Data database</source>
-        <translation type="unfinished">Варианты резервного копирования для базы данных Logs Data</translation>
-    </message>
-    <message>
-        <source>Backups</source>
-        <translation type="unfinished">Резервные копии</translation>
-    </message>
-    <message>
-        <source>A new backup is made when closing LogDoctor after having succesfully edited the database</source>
-        <translation type="unfinished">Новая резервная копия создается при закрытии LogDoctor после успешного редактирования базы данных</translation>
-    </message>
-    <message>
-        <source>Backup the Logs Data database and keep</source>
-        <translation type="unfinished">Резервное копирование базы данных Logs Data и сохранение</translation>
-    </message>
-    <message>
-        <source>Whether it is allowed or denied to follow symlinks occuring in a path</source>
-        <translation type="unfinished">Разрешено или запрещено следовать по симлинкам, возникающим на пути</translation>
-    </message>
-    <message>
-        <source>Follow symlinks</source>
-        <translation type="unfinished">Следуйте за симлинками</translation>
-    </message>
-    <message>
-        <source>Default WebServer</source>
-        <translation type="unfinished">По умолчанию WebServer</translation>
-    </message>
-    <message>
-        <source>Usage control</source>
-        <translation type="unfinished">Контроль использования</translation>
-    </message>
-    <message>
-        <source>Hide already used files</source>
-        <translation type="unfinished">Скрыть уже использованные файлы</translation>
-    </message>
-    <message>
-        <source>Size warnings</source>
-        <translation type="unfinished">Предупреждения о размере</translation>
-    </message>
-    <message>
-        <source>Warn me when using files with a size exceeding:</source>
-        <translation type="unfinished">Предупредите меня при использовании файлов с размером, превышающим:</translation>
-    </message>
-    <message>
-        <source>Logs folder</source>
-        <translation type="unfinished">Складка журналов</translation>
-    </message>
-    <message>
-        <source>Logs format string</source>
-        <translation type="unfinished">Формат строки Logs</translation>
-    </message>
-    <message>
-        <source>Format string</source>
-        <translation type="unfinished">Формат строки</translation>
-    </message>
-    <message>
-        <source>Insert the format string you&apos;re using</source>
-        <translation type="unfinished">Вставьте строку формата, которую вы используете</translation>
-    </message>
-    <message>
-        <source>Apply the current string</source>
-        <translation type="unfinished">Применять текущую строку</translation>
-    </message>
-    <message>
-        <source>Generate a sample log line from the currently saved string, to check if it gets formatted correctly.
-Any field not considered by LogDoctor will appear as &apos;DISCARDED&apos;</source>
-        <translation type="unfinished">Создайте строку журнала образца из сохраненной строки, чтобы проверить, правильно ли она отформатирована.
-Любое поле, не рассматриваемое LogDoctor, будет отображаться как &apos;DISCARDED&apos;</translation>
-    </message>
-    <message>
-        <source>Generate sample</source>
-        <translation type="unfinished">Сгенерировать образец</translation>
-    </message>
-    <message>
-        <source>Please check the correctness of this line.
+        <translation>СТАРТ</translation>
+    </message>
+    <message>
+    <source>Time elapsed since the start</source>
+    <translation>Время, прошедшее с начала</translation>
+</message>
+<message>
+    <source>Average speed, in parsed data size per second</source>
+    <translation>Средняя скорость (объём обработанных данных в секунду)</translation>
+</message>
+<message>
+    <source>Draw the chart</source>
+    <translation>Построить график</translation>
+</message>
+<message>
+    <source>Web Server</source>
+    <translation>Веб-сервер</translation>
+</message>
+<message>
+    <source>Select a Web Server</source>
+    <translation>Выберите веб-сервер</translation>
+</message>
+<message>
+    <source>Year</source>
+    <translation>Год</translation>
+</message>
+<message>
+    <source>Month</source>
+    <translation>Месяц</translation>
+</message>
+<message>
+    <source>Day</source>
+    <translation>День</translation>
+</message>
+<message>
+    <source>Hour</source>
+    <translation>Час</translation>
+</message>
+<message>
+    <source>Log line marked as Warning</source>
+    <translation>Строка лога, помеченная как предупреждение</translation>
+</message>
+<message>
+    <source>Date when the request arrived (YYYY-MM-DD)</source>
+    <translation>Дата поступления запроса (ГГГГ-ММ-ДД)</translation>
+</message>
+<message>
+    <source>Time when the request arrived (hh:mm:ss)</source>
+    <translation>Время поступления запроса (чч:мм:сс)</translation>
+</message>
+<message>
+    <source>Protocol of the request</source>
+    <translation>Протокол запроса</translation>
+</message>
+<message>
+    <source>Method of the request</source>
+    <translation>Метод запроса</translation>
+</message>
+<message>
+    <source>URI of the requested page</source>
+    <translation>URI запрашиваемой страницы</translation>
+</message>
+<message>
+    <source>Response code from the server</source>
+    <translation>Код ответа сервера</translation>
+</message>
+<message>
+    <source>IP address of the Client which made the request</source>
+    <translation>IP-адрес клиента, сделавшего запрос</translation>
+</message>
+<message>
+    <source>Size ib Bytes of the request, usually includes header and data</source>
+    <translation>Размер запроса в байтах (обычно включает заголовки и данные)</translation>
+</message>
+<message>
+    <source>Size in Bytes of the served content, usually includes header and data</source>
+    <translation>Размер отдаваемого контента в байтах (обычно включает заголовки и данные)</translation>
+</message>
+<message>
+    <source>Protocol:</source>
+    <translation>Протокол:</translation>
+</message>
+<message>
+    <source>Method:</source>
+    <translation>Метод:</translation>
+</message>
+<message>
+    <source>Response:</source>
+    <translation>Ответ:</translation>
+</message>
+<message>
+    <source>Query:</source>
+    <translation>Запрос:</translation>
+</message>
+<message>
+    <source>URI:</source>
+    <translation>URI:</translation>
+</message>
+<message>
+    <source>Filters</source>
+    <translation>Фильтры</translation>
+</message>
+<message>
+    <source>Query carried along with the URI</source>
+    <translation>Запрос, переданный вместе с URI</translation>
+</message>
+<message>
+    <source>Cookie used for the request</source>
+    <translation>Cookie, использованный в запросе</translation>
+</message>
+<message>
+    <source>User-agent of the client which made the request</source>
+    <translation>User-Agent клиента, сделавшего запрос</translation>
+</message>
+<message>
+    <source>Count</source>
+    <translation>Количество</translation>
+</message>
+<message>
+    <source>Number of occurrences</source>
+    <translation>Число вхождений</translation>
+</message>
+<message>
+    <source>Item</source>
+    <translation>Элемент</translation>
+</message>
+<message>
+    <source>Value of the field</source>
+    <translation>Значение поля</translation>
+</message>
+<message>
+    <source>From:</source>
+    <translation>От:</translation>
+</message>
+<message>
+    <source>To:</source>
+    <translation>До:</translation>
+</message>
+<message>
+    <source>Field:</source>
+    <translation>Поле:</translation>
+</message>
+<message>
+    <source>Select a log field to view</source>
+    <translation>Выберите поле лога для просмотра</translation>
+</message>
+<message>
+    <source>Filter:</source>
+    <translation>Фильтр:</translation>
+</message>
+<message>
+    <source>Protocol</source>
+    <translation>Протокол</translation>
+</message>
+<message>
+    <source>Method</source>
+    <translation>Метод</translation>
+</message>
+<message>
+    <source>URI</source>
+    <translation>URI</translation>
+</message>
+<message>
+    <source>User-agent</source>
+    <translation>User-Agent</translation>
+</message>
+<message>
+    <source>Most recurrent</source>
+    <translation>Наиболее повторяющееся</translation>
+</message>
+<message>
+    <source>Date ever</source>
+    <translation>Дата всех времён</translation>
+</message>
+<message>
+    <source>Day of the week</source>
+    <translation>День недели</translation>
+</message>
+<message>
+    <source>Hour of the day</source>
+    <translation>Час дня</translation>
+</message>
+<message>
+    <source>Most trafficked</source>
+    <translation>Наиболее загруженные</translation>
+</message>
+<message>
+    <source>Time taken</source>
+    <translation>Затраченное время</translation>
+</message>
+<message>
+    <source>Bytes sent</source>
+    <translation>Отправлено байт</translation>
+</message>
+<message>
+    <source>Bytes received</source>
+    <translation>Получено байт</translation>
+</message>
+<message>
+    <source>Mean/Max performances</source>
+    <translation>Средняя/максимальная производительность</translation>
+</message>
+<message>
+    <source>Requests received</source>
+    <translation>Получено запросов</translation>
+</message>
+<message>
+    <source>Total work</source>
+    <translation>Объём работы</translation>
+</message>
+<message>
+    <source>General</source>
+    <translation>Общее</translation>
+</message>
+<message>
+    <source>Window</source>
+    <translation>Окно</translation>
+</message>
+<message>
+    <source>Remember window&apos;s position and size</source>
+    <translation>Запомнить положение и размер окна</translation>
+</message>
+<message>
+    <source>Geometry</source>
+    <translation>Геометрия</translation>
+</message>
+<message>
+    <source>Theme to use for the window</source>
+    <translation>Тема оформления окна</translation>
+</message>
+<message>
+    <source>Theme</source>
+    <translation>Тема</translation>
+</message>
+<message>
+    <source>Dark</source>
+    <translation>Тёмная</translation>
+</message>
+<message>
+    <source>Dialogs</source>
+    <translation>Диалоги</translation>
+</message>
+<message>
+    <source>Dialogs level</source>
+    <translation>Уровень диалогов</translation>
+</message>
+<message>
+    <source>Reduced quantity of dialog messages shown</source>
+    <translation>Минимум диалоговых сообщений</translation>
+</message>
+<message>
+    <source>Essential</source>
+    <translation>Только важное</translation>
+</message>
+<message>
+    <source>Normal quantity of dialog messages shown</source>
+    <translation>Обычное количество диалогов</translation>
+</message>
+<message>
+    <source>Normal</source>
+    <translation>Обычный</translation>
+</message>
+<message>
+    <source>Explanatory</source>
+    <translation>Подробный</translation>
+</message>
+<message>
+    <source>Logs parser</source>
+    <translation>Парсер логов</translation>
+</message>
+<message>
+    <source>Statistics viewer</source>
+    <translation>Просмотр статистики</translation>
+</message>
+<message>
+    <source>TextBrowser</source>
+    <translation>Текстовый просмотр</translation>
+</message>
+<message>
+    <source>Font to use for the Text Browser</source>
+    <translation>Шрифт для текстового просмотра</translation>
+</message>
+<message>
+    <source>Font</source>
+    <translation>Шрифт</translation>
+</message>
+<message>
+    <source>Double-spaced lines</source>
+    <translation>Двойной интервал между строками</translation>
+</message>
+<message>
+    <source>Use wide lines</source>
+    <translation>Использовать широкие строки</translation>
+</message>
+<message>
+    <source>Define the spacing between lines</source>
+    <translation>Установить межстрочный интервал</translation>
+</message>
+<message>
+    <source>Lines spacing</source>
+    <translation>Интервал между строками</translation>
+</message>
+<message>
+    <source>None</source>
+    <translation>Нет</translation>
+</message>
+<message>
+    <source>Color scheme to use for the Text Browser</source>
+    <translation>Цветовая схема для текстового просмотра</translation>
+</message>
+<message>
+    <source>Color scheme</source>
+    <translation>Цветовая схема</translation>
+</message>
+<message>
+    <source>The appearance of the Text Browser with the current settings</source>
+    <translation>Внешний вид текстового просмотра с текущими настройками</translation>
+</message>
+<message>
+    <source>Preview</source>
+    <translation>Предпросмотр</translation>
+</message>
+<message>
+    <source>Charts</source>
+    <translation>Графики</translation>
+</message>
+<message>
+    <source>Theme to use for the Charts</source>
+    <translation>Тема для графиков</translation>
+</message>
+<message>
+    <source>Databases</source>
+    <translation>Базы данных</translation>
+</message>
+<message>
+    <source>Apply the current path</source>
+    <translation>Применить текущий путь</translation>
+</message>
+<message>
+    <source>Path where the logs data collection database is located</source>
+    <translation>Путь к базе данных с логами</translation>
+</message>
+<message>
+    <source>Logs data</source>
+    <translation>Данные логов</translation>
+</message>
+<message>
+    <source>The given path doen&apos;t exists, or doesn&apos;t point to a folder</source>
+    <translation>Указанный путь не существует или не указывает на папку</translation>
+</message>
+<message>
+    <source>Path where the used files hashes database is located</source>
+    <translation>Путь к базе данных хэшей использованных файлов</translation>
+</message>
+<message>
+    <source>Used files</source>
+    <translation>Использованные файлы</translation>
+</message>
+<message>
+    <source>Insert the base path only, file name excluded</source>
+    <translation>Укажите только базовый путь, без имени файла</translation>
+</message>
+<message>
+    <source>Path for the database files</source>
+    <translation>Путь к файлам базы данных</translation>
+</message>
+<message>
+    <source>Paths</source>
+    <translation>Пути</translation>
+</message>
+<message>
+    <source>Backup options for the Logs Data database</source>
+    <translation>Параметры резервного копирования базы логов</translation>
+</message>
+<message>
+    <source>Backups</source>
+    <translation>Резервные копии</translation>
+</message>
+<message>
+    <source>A new backup is made when closing LogDoctor after having succesfully edited the database</source>
+    <translation>Резервная копия создаётся при закрытии LogDoctor после успешного редактирования базы данных</translation>
+</message>
+<message>
+    <source>Backup the Logs Data database and keep</source>
+    <translation>Создать резервную копию базы логов и сохранить</translation>
+</message>
+<message>
+    <source>Logs</source>
+    <translation>Логи</translation>
+</message>
+<message>
+    <source>Defaults</source>
+    <translation>По умолчанию</translation>
+</message>
+<message>
+    <source>Default WebServer</source>
+    <translation>Веб-сервер по умолчанию</translation>
+</message>
+<message>
+    <source>Control</source>
+    <translation>Контроль</translation>
+</message>
+<message>
+    <source>Usage control</source>
+    <translation>Контроль использования</translation>
+</message>
+<message>
+    <source>Hide already used files</source>
+    <translation>Скрыть уже использованные файлы</translation>
+</message>
+<message>
+    <source>Size warnings</source>
+    <translation>Предупреждения о размере</translation>
+</message>
+<message>
+    <source>Warn me when using files with a size exceeding:</source>
+    <translation>Предупреждать, если размер файла превышает:</translation>
+</message>
+<message>
+    <source>Apache2</source>
+    <translation>Apache2</translation>
+</message>
+<message>
+    <source>Logs folder</source>
+    <translation>Папка логов</translation>
+</message>
+<message>
+    <source>Logs format string</source>
+    <translation>Строка формата логов</translation>
+</message>
+<message>
+    <source>Format string</source>
+    <translation>Форматная строка</translation>
+</message>
+<message>
+    <source>Insert the format string you&apos;re using</source>
+    <translation>Введите используемую строку формата</translation>
+</message>
+<message>
+    <source>Apply the current string</source>
+    <translation>Применить текущую строку</translation>
+</message>
+<message>
+    <source>Generate sample</source>
+    <translation>Сгенерировать пример</translation>
+</message>
+<message>
+    <source>Please check the correctness of this line.
 Fields marked as &apos;DISCARDED&apos; got parsed correctly, but are not considered by LogDoctor</source>
-        <translation type="unfinished">Пожалуйста, проверьте правильность этой строки.
-Поля, помеченные как &apos;DISCARDED&apos;, были правильно разобраны, но не рассматриваются LogDoctor</translation>
-    </message>
-    <message>
-        <source>Open an help window</source>
-        <translation type="unfinished">Откройте окно помощи</translation>
-    </message>
-    <message>
-        <source>Help</source>
-        <translation type="unfinished">Помощь</translation>
-    </message>
-    <message>
-        <source>Select a log field</source>
-        <translation type="unfinished">Выберите поле log</translation>
-    </message>
-    <message>
-        <source>Use warnlist for this field</source>
-        <translation type="unfinished">Используйте предупредительный список для этой области</translation>
-    </message>
-    <message>
-        <source>Add the current line to the list</source>
-        <translation type="unfinished">Добавить текущую строку в список</translation>
-    </message>
-    <message>
-        <source>Remove the selected item from the list</source>
-        <translation type="unfinished">Удалить выбранный пункт из списка</translation>
-    </message>
-    <message>
-        <source>Move the selected item down</source>
-        <translation type="unfinished">Переместите выбранный пункт вниз</translation>
-    </message>
-    <message>
-        <source>Use blacklist for this field</source>
-        <translation type="unfinished">Используйте черный список для этой области</translation>
-    </message>
-    <message>
-        <source>Add line</source>
-        <translation type="unfinished">Добавить строку</translation>
-    </message>
-    <message>
-        <source>Remove selection</source>
-        <translation type="unfinished">Удалить выбор</translation>
-    </message>
-    <message>
-        <source>Language</source>
-        <translation type="unfinished">Язык языка</translation>
-    </message>
-    <message>
-        <source>Utilities</source>
-        <translation type="unfinished">коммунальные услуги</translation>
-    </message>
-    <message>
-        <source>Tools</source>
-        <translation type="unfinished">Инструменты</translation>
-    </message>
-    <message>
-        <source>Games</source>
-        <translation type="unfinished">Игры</translation>
-    </message>
-    <message>
-        <source>Perform a version-check</source>
-        <translation type="unfinished">Проверить версию</translation>
-    </message>
-    <message>
-        <source>Show some info about LogDoctor</source>
-        <translation type="unfinished">Показать информацию о LogDoctor</translation>
-    </message>
-    <message>
-        <source>Open a block-note like window to write temporary text</source>
-        <translation type="unfinished">Откройте блок-ноту как окно для написания временного текста</translation>
-    </message>
-    <message>
-        <source>Play CrissCross</source>
-        <translation type="unfinished">Играть в CrissCross</translation>
-    </message>
-    <message>
-        <source>Play Snake</source>
-        <translation type="unfinished">Играть в Snake</translation>
-    </message>
-    <message>
-        <source>Show the changelog</source>
-        <translation type="unfinished">Показать changelog</translation>
-    </message>
-    <message>
-        <source>warnlist</source>
-        <translation type="unfinished">предупреждающий</translation>
-    </message>
-    <message>
-        <source>blacklist</source>
-        <translation type="unfinished">черный список</translation>
-    </message>
-    <message>
-        <source>copy</source>
-        <translation type="unfinished">копия</translation>
-    </message>
-    <message>
-        <source>copies</source>
-        <translation type="unfinished">копии</translation>
-    </message>
-    <message>
-        <source>Check updates</source>
-        <translation type="unfinished">Проверьте обновления</translation>
-    </message>
-    <message>
-        <source>Infos</source>
-        <translation type="unfinished">Информация</translation>
-    </message>
-    <message>
-        <source>BlockNote</source>
-        <translation type="unfinished">Блокнот</translation>
-    </message>
-    <message>
-        <source>CrissCross</source>
-        <translation type="unfinished">Перекресток</translation>
-    </message>
-    <message>
-        <source>Snake</source>
-        <translation type="unfinished">Змея</translation>
-    </message>
-    <message>
-        <source>Changelog</source>
-        <translation type="unfinished">Изменить</translation>
-    </message>
-</context>
+    <translation>Проверьте корректность этой строки.
+Поля, отмеченные как «DISCARDED», распознаны правильно, но не учитываются LogDoctor</translation>
+</message>
+<message>
+    <source>Open an help window</source>
+    <translation>Открыть окно справки</translation>
+</message>
+<message>
+    <source>Help</source>
+    <translation>Справка</translation>
+</message>
+<message>
+    <source>Warnlists</source>
+    <translation>Списки предупреждений</translation>
+</message>
+<message>
+    <source>Select a log field</source>
+    <translation>Выберите поле лога</translation>
+</message>
+<message>
+    <source>Use warnlist for this field</source>
+    <translation>Использовать список предупреждений для этого поля</translation>
+</message>
+<message>
+    <source>Add the current line to the list</source>
+    <translation>Добавить текущую строку в список</translation>
+</message>
+<message>
+    <source>Remove the selected item from the list</source>
+    <translation>Удалить выбранный элемент из списка</translation>
+</message>
+<message>
+    <source>Move the selected item down</source>
+    <translation>Переместить элемент вниз</translation>
+</message>
+<message>
+    <source>Blacklists</source>
+    <translation>Черные списки</translation>
+</message>
+<message>
+    <source>Use blacklist for this field</source>
+    <translation>Использовать чёрный список для этого поля</translation>
+</message>
+<message>
+    <source>Add line</source>
+    <translation>Добавить строку</translation>
+</message>
+<message>
+    <source>Remove selection</source>
+    <translation>Удалить выделенное</translation>
+</message>
+<message>
+    <source>Nginx</source>
+    <translation>Nginx</translation>
+</message>
+<message>
+    <source>IIS</source>
+    <translation>IIS</translation>
+</message>
+<message>
+    <source>Language</source>
+    <translation>Язык</translation>
+</message>
+<message>
+    <source>Utilities</source>
+    <translation>Утилиты</translation>
+</message>
+<message>
+    <source>Tools</source>
+    <translation>Инструменты</translation>
+</message>
+<message>
+    <source>Perform a version-check</source>
+    <translation>Проверить версию</translation>
+</message>
+<message>
+    <source>Open a block-note like window to write temporary text</source>
+    <translation>Открыть окно для временных заметок</translation>
+</message>
+<message>
+    <source>copy</source>
+    <translation>копия</translation>
+</message>
+<message>
+    <source>copies</source>
+    <translation>копии</translation>
+</message>
+<message>
+    <source>Time taken by the server to serve the content, in milliseconds</source>
+    <translation>Время, затраченное сервером на выдачу контента (в мс)</translation>
+</message>
+<message>
+    <source>Only use lines in which the field is starting with this string</source>
+    <translation>Использовать только строки, где поле начинается с этой строки</translation>
+</message>
+<message>
+    <source>Only use lines in which the field is matching this statement.
+Use '!', '=', '&lt;' or '&gt;' to declare what to use</source>
+    <translation>Использовать только строки, где поле соответствует условию.
+Используйте '!', '=', '&lt;' или '&gt;' для задания условия</translation>
+</message>
+<message>
+    <source>With strings, only the lines in which the field is starting with this string will be used.
+With numbers, use '!', '=', '&lt;' or '&gt;' to declare what to use</source>
+    <translation>Для строк — использовать только строки, где поле начинается с этого значения.
+Для чисел — используйте '!', '=', '&lt;' или '&gt;' для указания условия</translation>
+</message>
+<message>
+    <source>The URL which redirected the Client to the requested page</source>
+    <translation>URL, перенаправивший клиента на запрошенную страницу</translation>
+</message>
+<message>
+    <source>Remember the window&apos;s position and size</source>
+    <translation>Запомнить положение и размер окна</translation>
+</message>
+<message>
+    <source>Remember position and size</source>
+    <translation>Запомнить позицию и размер</translation>
+</message>
+<message>
+    <source>Define the quantity of dialog mesages shown</source>
+    <translation>Задать количество отображаемых диалоговых сообщений</translation>
+</message>
+<message>
+    <source>Augmented quantity of dialog messages shown</source>
+    <translation>Увеличенное количество диалоговых сообщений</translation>
+</message>
+<message>
+    <source>Dialogs from the main processes</source>
+    <translation>Диалоги от основных процессов</translation>
+</message>
+<message>
+    <source>Dialogs emitted when parsing logs</source>
+    <translation>Диалоги при разборе логов</translation>
+</message>
+<message>
+    <source>Dialogs emitted when viewing statistics</source>
+    <translation>Диалоги при просмотре статистики</translation>
+</message>
+<message>
+    <source>Format</source>
+    <translation>Формат</translation>
+</message>
+<message>
+    <source>Select/deselect all the files</source>
+    <translation>Выбрать/отменить выбор всех файлов</translation>
+</message>
+<message>
+    <source>warnlist</source>
+    <translation>warnlist</translation>
+</message>
+<message>
+    <source>blacklist</source>
+    <translation>blacklist</translation>
+</message>
+<message>
+    <source>Games</source>
+    <translation>Игры</translation>
+</message>
+<message>
+    <source>Play CrissCross</source>
+    <translation>Играть в CrissCross</translation>
+</message>
+<message>
+    <source>Play Snake</source>
+    <translation>Играть в Змейку</translation>
+</message>
+<message>
+    <source>Light</source>
+    <translation>Светлая</translation>
+</message>
+<message>
+    <source>Generate a sample log line from the currently saved string, to check if it gets formatted correctly.
+Any field not considered by LogDoctor will appear as 'DISCARDED'</source>
+    <translation>Сгенерировать пример строки лога из текущей сохранённой строки, чтобы проверить корректность форматирования.
+Любое поле, не распознаваемое LogDoctor, будет отображено как «DISCARDED»</translation>
+</message>
+<message>
+    <source>Icons</source>
+    <translation>Иконки</translation>
+</message>
+<message>
+    <source>Path</source>
+    <translation>Путь</translation>
+</message>
+<message>
+    <source>Native</source>
+    <translation>Системная</translation>
+</message>
+<message>
+    <source>Auto</source>
+    <translation>Авто</translation>
+</message>
+<message>
+    <source>Select the path through a dialog window</source>
+    <translation>Выбрать путь через диалоговое окно</translation>
+</message>
+<message>
+    <source>Show some info about LogDoctor</source>
+    <translation>Показать информацию о LogDoctor</translation>
+</message>
+<message>
+    <source>Show the changelog</source>
+    <translation>Показать список изменений</translation>
+</message>
+<message>
+    <source>Speed</source>
+    <translation>Скорость</translation>
+</message>
+<message>
+    <source>Represents a step in the time axis, in seconds.
+All the values falling inside the same interval will be merged and the mean value will be used.</source>
+    <translation>Представляет собой шаг на временной оси, в секундах.
+Все значения в пределах одного интервала будут объединены, и будет использовано среднее значение.</translation>
+</message>
+<message>
+    <source>Time interval</source>
+    <translation>Временной интервал</translation>
+</message>
+<message>
+    <source>The format to use for the labels of the time axis.</source>
+    <translation>Формат для подписей на временной оси.</translation>
+</message>
+<message>
+    <source>Time format</source>
+    <translation>Формат времени</translation>
+</message>
+<message>
+    <source>The size of the pie</source>
+    <translation>Размер диаграммы</translation>
+</message>
+<message>
+    <source>Pie size</source>
+    <translation>Размер круговой диаграммы</translation>
+</message>
+<message>
+    <source>The maximum number of slices that the pie will be composed of.
+Exceeding slices will be grouped into one comprehensive slice.</source>
+    <translation>Максимальное количество секторов на круговой диаграмме.
+Превышающие лимит сектора будут объединены в один.</translation>
+</message>
+<message>
+    <source>Maximum slices</source>
+    <translation>Максимум секторов</translation>
+</message>
+<message>
+    <source>Relational</source>
+    <translation>Реляционный</translation>
+</message>
+<message>
+    <source>Appearance</source>
+    <translation>Внешний вид</translation>
+</message>
+<message>
+    <source>Security</source>
+    <translation>Безопасность</translation>
+</message>
+<message>
+    <source>Whether it is allowed or denied to follow symlinks occuring in a path</source>
+    <translation>Разрешено ли следовать символьным ссылкам в указанном пути</translation>
+</message>
+<message>
+    <source>Follow symlinks</source>
+    <translation>Следовать по символьным ссылкам</translation>
+</message>
+<message>
+    <source>Check updates</source>
+    <translation>Проверить обновления</translation>
+</message>
+<message>
+    <source>Infos</source>
+    <translation>Информация</translation>
+</message>
+<message>
+    <source>BlockNote</source>
+    <translation>Заметки</translation>
+</message>
+<message>
+    <source>CrissCross</source>
+    <translation>CrissCross</translation>
+</message>
+<message>
+    <source>Snake</source>
+    <translation>Змейка</translation>
+</message>
+<message>
+    <source>Changelog</source>
+    <translation>Список изменений</translation>
+</message>
+
 <context>
     <name>RichText</name>
     <message>
         <source>Select a file from the list</source>
-        <translation type="unfinished">Выберите файл из списка</translation>
+        <translation>Выберите файл из списка</translation>
     </message>
     <message>
         <source>to inspect its content</source>
-        <translation type="unfinished">проверить его содержание</translation>
+        <translation>для просмотра его содержимого</translation>
     </message>
     <message>
         <source>Failed to read</source>
-        <translation type="unfinished">Не удалось прочитать</translation>
+        <translation>Не удалось прочитать</translation>
     </message>
 </context>
+
 <context>
     <name>SnakeGame</name>
     <message>
-        <source>PLAY</source>
-        <translation type="unfinished">играть</translation>
-    </message>
-    <message>
-        <source>Classic</source>
-        <translation type="unfinished">Классика</translation>
-    </message>
-    <message>
-        <source>Hunt</source>
-        <translation type="unfinished">охота</translation>
-    </message>
-    <message>
-        <source>Battle</source>
-        <translation type="unfinished">Битва</translation>
-    </message>
-    <message>
         <source>Game Over</source>
-        <translation type="unfinished">Обсуждение Game Over</translation>
+        <translation>Игра окончена</translation>
     </message>
     <message>
         <source>Your adversary fell in the water!</source>
-        <translation type="unfinished">Твой противник упал в воду!</translation>
-    </message>
-    <message>
-        <source>YOU WON!</source>
-        <translation type="unfinished">Ты победил!</translation>
-    </message>
-    <message>
-        <source>You fell in the water!</source>
-        <translation type="unfinished">Ты упал в воду!</translation>
-    </message>
-    <message>
-        <source>YOU LOST!</source>
-        <translation type="unfinished">Ты проиграл!</translation>
-    </message>
-    <message>
-        <source>Your adversary ate itself!</source>
-        <translation type="unfinished">Твой противник съел сам себя!</translation>
-    </message>
-    <message>
-        <source>You ate yourself!</source>
-        <translation type="unfinished">Ты съел себя!</translation>
-    </message>
-    <message>
-        <source>Your adversary ate you!</source>
-        <translation type="unfinished">Твой противник съел тебя!</translation>
-    </message>
-    <message>
-        <source>You ate your adversary!</source>
-        <translation type="unfinished">Ты съел своего противника!</translation>
-    </message>
-    <message>
-        <source>You ate each other!</source>
-        <translation type="unfinished">Вы съели друг друга!</translation>
-    </message>
-    <message>
-        <source>MATCH IS DRAW!</source>
-        <translation type="unfinished">Матч - это драка!</translation>
+        <translation>Ваш противник упал в воду!</translation>
     </message>
 </context>
-<context>
-    <name>TR</name>
-    <message>
-        <source>Unexpected WebServer</source>
-        <translation type="unfinished">Неожиданный веб-сервер</translation>
-    </message>
-    <message>
-        <source>Logs Size Breakdown</source>
-        <translation type="unfinished">Разбивка по размеру</translation>
-    </message>
-    <message>
-        <source>Ignored</source>
-        <translation type="unfinished">игнорируемый</translation>
-    </message>
-    <message>
-        <source>Parsed</source>
-        <translation type="unfinished">Парсед</translation>
-    </message>
-    <message>
-        <source>Blacklisted</source>
-        <translation type="unfinished">Черный список</translation>
-    </message>
-    <message>
-        <source>Others</source>
-        <translation type="unfinished">Другие</translation>
-    </message>
-    <message>
-        <source>from</source>
-        <translation type="unfinished">из</translation>
-    </message>
-    <message>
-        <source>to</source>
-        <translation type="unfinished">то</translation>
-    </message>
-    <message>
-        <source>Log Lines Marked as Warning</source>
-        <translation type="unfinished">Логические линии отмечены как предупреждение</translation>
-    </message>
-    <message>
-        <source>Time Taken to Serve Requests</source>
-        <translation type="unfinished">Время, необходимое для выполнения запросов</translation>
-    </message>
-    <message>
-        <source>Time of Day Count</source>
-        <translation type="unfinished">Счет времени суток</translation>
-    </message>
-    <message>
-        <source>Relational Count</source>
-        <translation type="unfinished">Относительный счет</translation>
-    </message>
-    <message>
-        <source>FALSE</source>
-        <translation type="unfinished">ложный</translation>
-    </message>
-    <message>
-        <source>TRUE</source>
-        <translation type="unfinished">Правда</translation>
-    </message>
-    <message>
-        <source>Date</source>
-        <translation type="unfinished">Дата</translation>
-    </message>
-    <message>
-        <source>Year</source>
-        <translation type="unfinished">Год</translation>
-    </message>
-    <message>
-        <source>Month</source>
-        <translation type="unfinished">месяц</translation>
-    </message>
-    <message>
-        <source>Day</source>
-        <translation type="unfinished">День</translation>
-    </message>
-    <message>
-        <source>Time</source>
-        <translation type="unfinished">Время</translation>
-    </message>
-    <message>
-        <source>Hour</source>
-        <translation type="unfinished">Час</translation>
-    </message>
-    <message>
-        <source>Minute</source>
-        <translation type="unfinished">Минута</translation>
-    </message>
-    <message>
-        <source>Second</source>
-        <translation type="unfinished">Второй</translation>
-    </message>
-    <message>
-        <source>Warning</source>
-        <translation type="unfinished">Предупреждение</translation>
-    </message>
-    <message>
-        <source>Protocol</source>
-        <translation type="unfinished">Протокол</translation>
-    </message>
-    <message>
-        <source>Method</source>
-        <translation type="unfinished">метод</translation>
-    </message>
-    <message>
-        <source>URI</source>
-        <translation type="unfinished">Ури</translation>
-    </message>
-    <message>
-        <source>Query</source>
-        <translation type="unfinished">Запрос</translation>
-    </message>
-    <message>
-        <source>Response code</source>
-        <translation type="unfinished">Код ответа</translation>
-    </message>
-    <message>
-        <source>Time taken</source>
-        <translation type="unfinished">Время</translation>
-    </message>
-    <message>
-        <source>Bytes sent</source>
-        <translation type="unfinished">отправленные байты</translation>
-    </message>
-    <message>
-        <source>Bytes received</source>
-        <translation type="unfinished">Полученные байты</translation>
-    </message>
-    <message>
-        <source>Referrer</source>
-        <translation type="unfinished">Реферер</translation>
-    </message>
-    <message>
-        <source>Cookie</source>
-        <translation type="unfinished">печенье</translation>
-    </message>
-    <message>
-        <source>Client</source>
-        <translation type="unfinished">клиент</translation>
-    </message>
-    <message>
-        <source>User-agent</source>
-        <translation type="unfinished">Агент-пользователь</translation>
-    </message>
-    <message>
-        <source>January</source>
-        <translation type="unfinished">Январь</translation>
-    </message>
-    <message>
-        <source>February</source>
-        <translation type="unfinished">февраль</translation>
-    </message>
-    <message>
-        <source>March</source>
-        <translation type="unfinished">март</translation>
-    </message>
-    <message>
-        <source>April</source>
-        <translation type="unfinished">апрель</translation>
-    </message>
-    <message>
-        <source>May</source>
-        <translation type="unfinished">май</translation>
-    </message>
-    <message>
-        <source>June</source>
-        <translation type="unfinished">июнь</translation>
-    </message>
-    <message>
-        <source>July</source>
-        <translation type="unfinished">июль</translation>
-    </message>
-    <message>
-        <source>August</source>
-        <translation type="unfinished">август</translation>
-    </message>
-    <message>
-        <source>September</source>
-        <translation type="unfinished">сентябрь</translation>
-    </message>
-    <message>
-        <source>October</source>
-        <translation type="unfinished">октября</translation>
-    </message>
-    <message>
-        <source>November</source>
-        <translation type="unfinished">ноябрь</translation>
-    </message>
-    <message>
-        <source>December</source>
-        <translation type="unfinished">декабрь</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished">воскресенье</translation>
-    </message>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished">понедельник</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished">вторник</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished">среда</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished">четверг</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished">Пятница</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished">суббота</translation>
-    </message>
+<message>
+    <source>You fell in the water!</source>
+    <translation>Вы упали в воду!</translation>
+</message>
+<message>
+    <source>YOU LOST!</source>
+    <translation>ВЫ ПРОИГРАЛИ!</translation>
+</message>
+<message>
+    <source>You ate yourself!</source>
+    <translation>Вы съели сами себя!</translation>
+</message>
+<message>
+    <source>You ate your adversary!</source>
+    <translation>Вы съели своего противника!</translation>
+</message>
+<message>
+    <source>You ate each other!</source>
+    <translation>Вы съели друг друга!</translation>
+</message>
+<message>
+    <source>MATCH IS DRAW!</source>
+    <translation>НИЧЬЯ!</translation>
+</message>
+<message>
+    <source>Your adversary ate itself!</source>
+    <translation>Ваш противник съел сам себя!</translation>
+</message>
+<message>
+    <source>Your adversary ate you!</source>
+    <translation>Ваш противник съел вас!</translation>
+</message>
+<message>
+    <source>PLAY</source>
+    <translation>ИГРАТЬ</translation>
+</message>
+<message>
+    <source>Classic</source>
+    <translation>Классика</translation>
+</message>
+<message>
+    <source>Hunt</source>
+    <translation>Охота</translation>
+</message>
+<message>
+    <source>Battle</source>
+    <translation>Битва</translation>
+</message>
+<message>
+    <source>YOU WON!</source>
+    <translation>ВЫ ВЫИГРАЛИ!</translation>
+</message>
+<message>
+    <source>October</source>
+    <translation>Октябрь</translation>
+</message>
+<message>
+    <source>November</source>
+    <translation>Ноябрь</translation>
+</message>
+<message>
+    <source>December</source>
+    <translation>Декабрь</translation>
+</message>
+<message>
+    <source>Sunday</source>
+    <translation>Воскресенье</translation>
+</message>
+<message>
+    <source>Monday</source>
+    <translation>Понедельник</translation>
+</message>
+<message>
+    <source>Tuesday</source>
+    <translation>Вторник</translation>
+</message>
+<message>
+    <source>Wednesday</source>
+    <translation>Среда</translation>
+</message>
+<message>
+    <source>Thursday</source>
+    <translation>Четверг</translation>
+</message>
+<message>
+    <source>Friday</source>
+    <translation>Пятница</translation>
+</message>
+<message>
+    <source>Saturday</source>
+    <translation>Суббота</translation>
+</message>
+<message>
+    <source>Relational Count</source>
+    <translation>Относительное количество</translation>
+</message>
+<message>
+    <source>Year</source>
+    <translation>Год</translation>
+</message>
+<message>
+    <source>Month</source>
+    <translation>Месяц</translation>
+</message>
+<message>
+    <source>Day</source>
+    <translation>День</translation>
+</message>
+<message>
+    <source>Hour</source>
+    <translation>Час</translation>
+</message>
+<message>
+    <source>Minute</source>
+    <translation>Минута</translation>
+</message>
+<message>
+    <source>Second</source>
+    <translation>Секунда</translation>
+</message>
 </context>
 </TS>


### PR DESCRIPTION
Improved Russian translation (`logdoctor/translations/LogDoctor_ru_RU.ts`) by correcting
and filling in missing strings. All `<translation>` tags remain marked `type="unfinished"` 
for final review. Verified UTF-8 encoding.
